### PR TITLE
ACME validation methods added, along with response details and refactored tests.

### DIFF
--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -16,7 +16,6 @@ class CaaCheckParameters(BaseModel):
 
 class DcvValidationDetails(BaseModel, ABC):
     validation_method: DcvValidationMethod
-    challenge_value: str
     # DNS records have 5 fields: name, ttl, class, type, rdata (which can be multipart itself)
     # A or AAAA: name=domain_name type=A <rdata:address> (ip address)
     # CNAME: name=domain_name_x type=CNAME <rdata:domain_name>
@@ -25,13 +24,15 @@ class DcvValidationDetails(BaseModel, ABC):
 
 class DcvWebsiteChangeValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
+    challenge_value: str
     http_token_path: str
-    url_scheme: UrlScheme
+    url_scheme: UrlScheme = UrlScheme.HTTP
     # TODO add optional flag to iterate up through the domain hierarchy
 
 
 class DcvDnsChangeValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
+    challenge_value: str
     dns_name_prefix: str
     dns_record_type: DnsRecordType
 

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -42,8 +42,10 @@ class DcvAcmeHttp01ValidationDetails(DcvValidationDetails):
     token: str
     key_authorization: str
 
-# TODO DcvAcmeDns01ValidationDetails
-#      fields: key_authorization
+
+class DcvAcmeDns01ValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.ACME_DNS_01] = DcvValidationMethod.ACME_DNS_01
+    key_authorization: str
 # Please deploy a DNS TXT record under the name
 # _acme-challenge.<domain.com> with the following value:  667drNmQL3vX6bu8YZlgy0wKNBlCny8yrjF1lSaUndc
 
@@ -52,5 +54,6 @@ class DcvCheckParameters(BaseModel):
     validation_details: Union[
         DcvWebsiteChangeValidationDetails,
         DcvDnsChangeValidationDetails,
-        DcvAcmeHttp01ValidationDetails
+        DcvAcmeHttp01ValidationDetails,
+        DcvAcmeDns01ValidationDetails
     ]

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
+from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 
 
 class CaaCheckParameters(BaseModel):
@@ -22,13 +23,15 @@ class DcvValidationDetails(BaseModel, ABC):
     # TXT: name=domain_name type=TXT <rdata:text> (freeform text)
 
 
-class DcvHttpGenericValidationDetails(DcvValidationDetails):
-    validation_method: Literal[DcvValidationMethod.HTTP_GENERIC] = DcvValidationMethod.HTTP_GENERIC
+class DcvWebsiteChangeValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
     http_token_path: str
+    url_scheme: UrlScheme
+    # TODO add optional flag to iterate up through the domain hierarchy
 
 
-class DcvDnsGenericValidationDetails(DcvValidationDetails):
-    validation_method: Literal[DcvValidationMethod.DNS_GENERIC] = DcvValidationMethod.DNS_GENERIC
+class DcvDnsChangeValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
     dns_name_prefix: str
     dns_record_type: DnsRecordType
 
@@ -37,4 +40,4 @@ class DcvDnsGenericValidationDetails(DcvValidationDetails):
 
 
 class DcvCheckParameters(BaseModel):
-    validation_details: Union[DcvHttpGenericValidationDetails, DcvDnsGenericValidationDetails]
+    validation_details: Union[DcvWebsiteChangeValidationDetails, DcvDnsChangeValidationDetails]

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -37,12 +37,20 @@ class DcvDnsChangeValidationDetails(DcvValidationDetails):
     dns_record_type: DnsRecordType
 
 
-# TODO DcvAcmeHttp01ValidationDetails
-#      fields: token, key_authorization
+class DcvAcmeHttp01ValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.ACME_HTTP_01] = DcvValidationMethod.ACME_HTTP_01
+    token: str
+    key_authorization: str
 
 # TODO DcvAcmeDns01ValidationDetails
 #      fields: key_authorization
+# Please deploy a DNS TXT record under the name
+# _acme-challenge.<domain.com> with the following value:  667drNmQL3vX6bu8YZlgy0wKNBlCny8yrjF1lSaUndc
 
 
 class DcvCheckParameters(BaseModel):
-    validation_details: Union[DcvWebsiteChangeValidationDetails, DcvDnsChangeValidationDetails]
+    validation_details: Union[
+        DcvWebsiteChangeValidationDetails,
+        DcvDnsChangeValidationDetails,
+        DcvAcmeHttp01ValidationDetails
+    ]

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -36,7 +36,11 @@ class DcvDnsChangeValidationDetails(DcvValidationDetails):
     dns_record_type: DnsRecordType
 
 
-# TODO DcvAcmeValidationDetails
+# TODO DcvAcmeHttp01ValidationDetails
+#      fields: token, key_authorization
+
+# TODO DcvAcmeDns01ValidationDetails
+#      fields: key_authorization
 
 
 class DcvCheckParameters(BaseModel):

--- a/src/open_mpic_core/common_domain/check_response.py
+++ b/src/open_mpic_core/common_domain/check_response.py
@@ -9,13 +9,14 @@ from typing_extensions import Annotated
 
 class BaseCheckResponse(BaseModel):
     perspective_code: str
-    check_passed: bool = False
+    check_passed: bool = False  # TODO rename to is_valid ?
     errors: list[MpicValidationError] | None = None
     timestamp_ns: int | None = None  # TODO what do we name this field?
 
 
 class CaaCheckResponse(BaseCheckResponse):
     check_type: Literal[CheckType.CAA] = CheckType.CAA
+    # attestation -- object... digital signatures from remote perspective to allow result to be verified
     details: CaaCheckResponseDetails
 
 

--- a/src/open_mpic_core/common_domain/check_response.py
+++ b/src/open_mpic_core/common_domain/check_response.py
@@ -1,5 +1,6 @@
 from typing import Union, Literal
 
+from open_mpic_core.common_domain.check_response_details import CaaCheckResponseDetails, DcvCheckResponseDetails
 from open_mpic_core.common_domain.validation_error import MpicValidationError
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from pydantic import BaseModel, Field
@@ -13,21 +14,9 @@ class BaseCheckResponse(BaseModel):
     timestamp_ns: int | None = None  # TODO what do we name this field?
 
 
-class CaaCheckResponseDetails(BaseModel):
-    caa_record_present: bool = False  # TODO allow None to reflect potential error state
-    found_at: str | None = None
-    response: str | None = None
-
-
 class CaaCheckResponse(BaseCheckResponse):
     check_type: Literal[CheckType.CAA] = CheckType.CAA
     details: CaaCheckResponseDetails
-
-
-class DcvCheckResponseDetails(BaseModel):
-    http_generic: dict | None = None  # rename?
-    dns_generic: dict | None = None  # rename?
-    # FIXME probably need to define details instead of just a dict
 
 
 class DcvCheckResponse(BaseCheckResponse):

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -15,8 +15,8 @@ class DcvWebsiteChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
     # response_history -- list of redirects given before final response found
     #    each redirect: status_code, url
-    # response_url -- string with final response
-    # response_status_code -- int with response from response_url
+    response_url: str | None = None
+    response_status_code: int | None = None
     # response_page -- base64 encoding of first 100 bytes of page returned at final url
     # resolved_ip -- ip address used to communicate with domain_or_ip_target
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -33,13 +33,16 @@ class DcvDnsChangeResponseDetails(BaseModel):
 
 
 class DcvAcmeHttp01ResponseDetails(DcvWebsiteChangeResponseDetails):
-    pass
+    validation_method: Literal[DcvValidationMethod.ACME_HTTP_01] = DcvValidationMethod.ACME_HTTP_01
 
-# class DcvAcmeDns01ResponseDetails(BaseModel): same as DcvDnsChangeResponseDetails
+
+class DcvAcmeDns01ResponseDetails(DcvDnsChangeResponseDetails):
+    validation_method: Literal[DcvValidationMethod.ACME_DNS_01] = DcvValidationMethod.ACME_DNS_01
 
 
 DcvCheckResponseDetails = Annotated[Union[
-    DcvWebsiteChangeResponseDetails, DcvDnsChangeResponseDetails
+    DcvWebsiteChangeResponseDetails, DcvDnsChangeResponseDetails,
+    DcvAcmeHttp01ResponseDetails, DcvAcmeDns01ResponseDetails,
 ], Field(discriminator='validation_method')]
 
 
@@ -49,5 +52,6 @@ class DcvCheckResponseDetailsBuilder:
     def build_response_details(validation_method: DcvValidationMethod) -> DcvCheckResponseDetails:
         types = {DcvValidationMethod.WEBSITE_CHANGE_V2: DcvWebsiteChangeResponseDetails,
                  DcvValidationMethod.DNS_CHANGE: DcvDnsChangeResponseDetails,
-                 DcvValidationMethod.ACME_HTTP_01: DcvAcmeHttp01ResponseDetails}
+                 DcvValidationMethod.ACME_HTTP_01: DcvAcmeHttp01ResponseDetails,
+                 DcvValidationMethod.ACME_DNS_01: DcvAcmeDns01ResponseDetails}
         return types[validation_method]()

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -11,10 +11,14 @@ class CaaCheckResponseDetails(BaseModel):
     response: str | None = None  # base64 format of DNS RRset of response to CAA query
 
 
+class RedirectResponse(BaseModel):
+    status_code: int
+    url: str  # rename to location?
+
+
 class DcvWebsiteChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
-    # response_history -- list of redirects given before final response found
-    #    each redirect: status_code, url
+    response_history: list[RedirectResponse] | None = None
     response_url: str | None = None
     response_status_code: int | None = None
     # response_page -- base64 encoding of first 100 bytes of page returned at final url

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -32,7 +32,9 @@ class DcvDnsChangeResponseDetails(BaseModel):
     ad_flag: bool | None = None  # was AD flag set in DNS response
 
 
-# class DcvAcmeHttp01ResponseDetails(BaseModel): same as DcvWebsiteChangeResponseDetails
+class DcvAcmeHttp01ResponseDetails(DcvWebsiteChangeResponseDetails):
+    pass
+
 # class DcvAcmeDns01ResponseDetails(BaseModel): same as DcvDnsChangeResponseDetails
 
 
@@ -46,5 +48,6 @@ class DcvCheckResponseDetailsBuilder:
     @staticmethod
     def build_response_details(validation_method: DcvValidationMethod) -> DcvCheckResponseDetails:
         types = {DcvValidationMethod.WEBSITE_CHANGE_V2: DcvWebsiteChangeResponseDetails,
-                 DcvValidationMethod.DNS_CHANGE: DcvDnsChangeResponseDetails}
+                 DcvValidationMethod.DNS_CHANGE: DcvDnsChangeResponseDetails,
+                 DcvValidationMethod.ACME_HTTP_01: DcvAcmeHttp01ResponseDetails}
         return types[validation_method]()

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -6,17 +6,30 @@ from typing_extensions import Annotated
 
 
 class CaaCheckResponseDetails(BaseModel):
-    caa_record_present: bool = False  # TODO allow None to reflect potential error state
-    found_at: str | None = None
-    response: str | None = None
+    caa_record_present: bool = False  # TODO allow None to reflect potential error state; rename to just 'present'?
+    found_at: str | None = None  # domain where CAA record was found
+    response: str | None = None  # base64 format of DNS RRset of response to CAA query
 
 
 class DcvWebsiteChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
+    # response_history -- list of redirects given before final response found
+    #    each redirect: status_code, url
+    # response_url -- string with final response
+    # response_status_code -- int with response from response_url
+    # response_page -- base64 encoding of first 100 bytes of page returned at final url
+    # resolved_ip -- ip address used to communicate with domain_or_ip_target
 
 
 class DcvDnsChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
+    # records_seen -- list of records found in DNS query; base 64 encoding of RRset
+    # status_code -- dns response code
+    # ad_flag -- boolean indicating if AD flag was set in DNS response
+
+
+# class DcvAcmeHttp01ResponseDetails(BaseModel): same as DcvWebsiteChangeResponseDetails
+# class DcvAcmeDns01ResponseDetails(BaseModel): same as DcvDnsChangeResponseDetails
 
 
 DcvCheckResponseDetails = Annotated[Union[

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -27,7 +27,7 @@ class DcvWebsiteChangeResponseDetails(BaseModel):
 
 class DcvDnsChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
-    # records_seen -- list of records found in DNS query; base 64 encoding of RRset
+    records_seen: list[str] | None = None  # list of records found in DNS query; base64 encoding of RRset
     # status_code -- dns response code
     # ad_flag -- boolean indicating if AD flag was set in DNS response
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -1,0 +1,33 @@
+from typing import Union, Literal
+
+from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+
+class CaaCheckResponseDetails(BaseModel):
+    caa_record_present: bool = False  # TODO allow None to reflect potential error state
+    found_at: str | None = None
+    response: str | None = None
+
+
+class DcvWebsiteChangeResponseDetails(BaseModel):
+    validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
+
+
+class DcvDnsChangeResponseDetails(BaseModel):
+    validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
+
+
+DcvCheckResponseDetails = Annotated[Union[
+    DcvWebsiteChangeResponseDetails, DcvDnsChangeResponseDetails
+], Field(discriminator='validation_method')]
+
+
+# utility class
+class DcvCheckResponseDetailsBuilder:
+    @staticmethod
+    def build_response_details(validation_method: DcvValidationMethod) -> DcvCheckResponseDetails:
+        types = {DcvValidationMethod.WEBSITE_CHANGE_V2: DcvWebsiteChangeResponseDetails,
+                 DcvValidationMethod.DNS_CHANGE: DcvDnsChangeResponseDetails}
+        return types[validation_method]()

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -7,8 +7,8 @@ from typing_extensions import Annotated
 
 class CaaCheckResponseDetails(BaseModel):
     caa_record_present: bool = False  # TODO allow None to reflect potential error state; rename to just 'present'?
-    found_at: str | None = None  # domain where CAA record was found
-    response: str | None = None  # base64 format of DNS RRset of response to CAA query
+    found_at: str | None = None  # domain where CAA record was found  # FIXME set this properly
+    response: str | None = None  # base64 format of DNS RRset of response to CAA query  # FIXME set this properly
 
 
 class RedirectResponse(BaseModel):
@@ -18,10 +18,10 @@ class RedirectResponse(BaseModel):
 
 class DcvWebsiteChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.WEBSITE_CHANGE_V2] = DcvValidationMethod.WEBSITE_CHANGE_V2
-    response_history: list[RedirectResponse] | None = None
+    response_history: list[RedirectResponse] | None = None  # list of redirects followed to final page
     response_url: str | None = None
     response_status_code: int | None = None
-    # response_page -- base64 encoding of first 100 bytes of page returned at final url
+    response_page: str | None = None  # base64 encoding of first 100 bytes of page returned at final url
     # resolved_ip -- ip address used to communicate with domain_or_ip_target
 
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -21,13 +21,13 @@ class DcvWebsiteChangeResponseDetails(BaseModel):
     response_history: list[RedirectResponse] | None = None  # list of redirects followed to final page
     response_url: str | None = None
     response_status_code: int | None = None
-    response_page: str | None = None  # base64 encoding of first 100 bytes of page returned at final url
+    response_page: str | None = None  # first 100 bytes of page returned at final url (not base64 encoded)
     # resolved_ip -- ip address used to communicate with domain_or_ip_target
 
 
 class DcvDnsChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
-    records_seen: list[str] | None = None  # list of records found in DNS query; base64 encoding of RRset
+    records_seen: list[str] | None = None  # list of records found in DNS query; not base64 encoded
     # status_code -- dns response code
     # ad_flag -- boolean indicating if AD flag was set in DNS response
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -28,7 +28,7 @@ class DcvWebsiteChangeResponseDetails(BaseModel):
 class DcvDnsChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
     records_seen: list[str] | None = None  # list of records found in DNS query; not base64 encoded
-    # status_code -- dns response code
+    response_code: int | None = None  # DNS response code
     # ad_flag -- boolean indicating if AD flag was set in DNS response
 
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -29,7 +29,7 @@ class DcvDnsChangeResponseDetails(BaseModel):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
     records_seen: list[str] | None = None  # list of records found in DNS query; not base64 encoded
     response_code: int | None = None  # DNS response code
-    # ad_flag -- boolean indicating if AD flag was set in DNS response
+    ad_flag: bool | None = None  # was AD flag set in DNS response
 
 
 # class DcvAcmeHttp01ResponseDetails(BaseModel): same as DcvWebsiteChangeResponseDetails

--- a/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
+++ b/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
@@ -2,10 +2,8 @@ from enum import StrEnum
 
 
 class DcvValidationMethod(StrEnum):
-    HTTP_GENERIC = 'http-generic'  # TODO rename to something better
-    DNS_GENERIC = 'dns-generic'  # TODO rename to something better
-    # WEBSITE_CHANGE_V2 = 'website-change-v2'  # HTTP (need to specify if HTTP or HTTPS)
-    # ACME_HTTP_01 = 'acme-http-01'
-    # ACME_DNS_01 = 'acme-dns-01'
-    # ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'
-    # DNS_CHANGE = 'dns-change'
+    WEBSITE_CHANGE_V2 = 'website-change-v2'  # need to additionally specify if HTTP or HTTPS
+    DNS_CHANGE = 'dns-change'
+    ACME_HTTP_01 = 'acme-http-01'  # TODO not implemented yet
+    ACME_DNS_01 = 'acme-dns-01'  # TODO not implemented yet
+    ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'  # TODO not implemented yet

--- a/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
+++ b/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
@@ -5,5 +5,5 @@ class DcvValidationMethod(StrEnum):
     WEBSITE_CHANGE_V2 = 'website-change-v2'
     DNS_CHANGE = 'dns-change'
     ACME_HTTP_01 = 'acme-http-01'
-    ACME_DNS_01 = 'acme-dns-01'  # TODO not implemented yet
-    ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'  # TODO not implemented yet
+    ACME_DNS_01 = 'acme-dns-01'
+    ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'  # not implemented yet

--- a/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
+++ b/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
@@ -2,8 +2,8 @@ from enum import StrEnum
 
 
 class DcvValidationMethod(StrEnum):
-    WEBSITE_CHANGE_V2 = 'website-change-v2'  # need to additionally specify if HTTP or HTTPS
+    WEBSITE_CHANGE_V2 = 'website-change-v2'
     DNS_CHANGE = 'dns-change'
-    ACME_HTTP_01 = 'acme-http-01'  # TODO not implemented yet
+    ACME_HTTP_01 = 'acme-http-01'
     ACME_DNS_01 = 'acme-dns-01'  # TODO not implemented yet
     ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'  # TODO not implemented yet

--- a/src/open_mpic_core/common_domain/enum/url_scheme.py
+++ b/src/open_mpic_core/common_domain/enum/url_scheme.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class UrlScheme(StrEnum):
+    HTTP = 'http'  # TODO caps or lowercase? check API spec...
+    HTTPS = 'https'

--- a/src/open_mpic_core/common_domain/remote_perspective.py
+++ b/src/open_mpic_core/common_domain/remote_perspective.py
@@ -2,10 +2,10 @@ from pydantic import BaseModel
 
 
 class RemotePerspective(BaseModel):
-    code: str
-    # name seems to be an unused var and based on the spec the dot code seems to uniquely define a perspective.
-    name: str | None = None
-    rir: str
+    code: str  # example: "us-west-2"
+    # name seems to be an unused var and based on the spec the code seems to uniquely define a perspective.
+    name: str | None = None  # example: "US West (Oregon)"
+    rir: str  # example: "ARIN"
     too_close_codes: list[str] | None = []
 
     def is_perspective_too_close(self, perspective):

--- a/src/open_mpic_core/mpic_coordinator/domain/enum/request_path.py
+++ b/src/open_mpic_core/mpic_coordinator/domain/enum/request_path.py
@@ -1,8 +1,0 @@
-from enum import StrEnum
-
-
-class RequestPath(StrEnum):
-    """
-    Enum for request path; only allows one value: /mpic
-    """
-    MPIC = '/mpic'

--- a/src/open_mpic_core/mpic_coordinator/domain/mpic_orchestration_parameters.py
+++ b/src/open_mpic_core/mpic_coordinator/domain/mpic_orchestration_parameters.py
@@ -9,9 +9,8 @@ class BaseMpicOrchestrationParameters(BaseModel, ABC):
 
 class MpicRequestOrchestrationParameters(BaseMpicOrchestrationParameters):
     max_attempts: int | None = None
-    perspectives: list[str] | None = None  # for diagnostic purposes
+    perspectives: list[str] | None = None  # FIXME remove this or implement diagnostics mode for it
 
 
 class MpicEffectiveOrchestrationParameters(BaseMpicOrchestrationParameters):
     attempt_count: int | None = 1
-

--- a/src/open_mpic_core/mpic_coordinator/domain/mpic_orchestration_parameters.py
+++ b/src/open_mpic_core/mpic_coordinator/domain/mpic_orchestration_parameters.py
@@ -9,7 +9,6 @@ class BaseMpicOrchestrationParameters(BaseModel, ABC):
 
 class MpicRequestOrchestrationParameters(BaseMpicOrchestrationParameters):
     max_attempts: int | None = None
-    perspectives: list[str] | None = None  # FIXME remove this or implement diagnostics mode for it
 
 
 class MpicEffectiveOrchestrationParameters(BaseMpicOrchestrationParameters):

--- a/src/open_mpic_core/mpic_coordinator/domain/mpic_request.py
+++ b/src/open_mpic_core/mpic_coordinator/domain/mpic_request.py
@@ -15,12 +15,6 @@ class BaseMpicRequest(BaseModel, ABC):
     check_type: CheckType
     orchestration_parameters: MpicRequestOrchestrationParameters | None = None
 
-    @model_validator(mode='after')
-    def check_perspectives_and_perspective_count_together(self) -> 'BaseMpicRequest':
-        if self.orchestration_parameters:
-            assert not (self.orchestration_parameters.perspectives and self.orchestration_parameters.perspective_count), "Request contains both 'perspectives' and 'perspective_count'."
-        return self
-
 
 class MpicCaaRequest(BaseMpicRequest):
     check_type: Literal[CheckType.CAA] = CheckType.CAA

--- a/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
@@ -56,16 +56,9 @@ class MpicCoordinator:
 
         orchestration_parameters = mpic_request.orchestration_parameters
 
-        # Determine the perspectives and perspective count to use for this request.
-        # TODO revisit this when diagnostic mode (allowing 'perspectives') is implemented
         perspective_count = self.default_perspective_count
-        if orchestration_parameters is not None:
-            if orchestration_parameters.perspectives is not None:
-                perspectives_to_use = orchestration_parameters.perspectives
-                perspective_count = len(perspectives_to_use)
-            else:
-                if orchestration_parameters.perspective_count is not None:
-                    perspective_count = orchestration_parameters.perspective_count
+        if orchestration_parameters is not None and orchestration_parameters.perspective_count is not None:
+            perspective_count = orchestration_parameters.perspective_count
 
         perspective_cohorts = self.create_cohorts_of_randomly_selected_perspectives(self.target_perspectives,
                                                                                     perspective_count,

--- a/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
@@ -10,6 +10,7 @@ import hashlib
 from open_mpic_core.common_domain.check_response import CaaCheckResponse, \
     CaaCheckResponseDetails, DcvCheckResponse, DcvCheckResponseDetails
 from open_mpic_core.common_domain.check_request import CaaCheckRequest, DcvCheckRequest
+from open_mpic_core.common_domain.check_response_details import DcvCheckResponseDetailsBuilder
 from open_mpic_core.common_domain.validation_error import MpicValidationError
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from open_mpic_core.common_domain.messages.ErrorMessages import ErrorMessages
@@ -178,12 +179,14 @@ class MpicCoordinator:
                                 timestamp_ns=time.time_ns()
                             )
                         case CheckType.DCV:
+                            dcv_check_request: DcvCheckRequest = call_configuration.check_request
+                            validation_method = dcv_check_request.dcv_check_parameters.validation_details.validation_method
                             check_error_response = DcvCheckResponse(
                                 perspective_code=perspective.code,
                                 check_passed=False,
                                 errors=[MpicValidationError(error_type=ErrorMessages.COORDINATOR_COMMUNICATION_ERROR.key,
                                                             error_message=ErrorMessages.COORDINATOR_COMMUNICATION_ERROR.message)],
-                                details=DcvCheckResponseDetails(),  # TODO what should go here in this case?
+                                details=DcvCheckResponseDetailsBuilder.build_response_details(validation_method),  # TODO what should go here in this case?
                                 timestamp_ns=time.time_ns()
                             )
                     validity_per_perspective[perspective.code] |= check_error_response.check_passed

--- a/src/open_mpic_core/mpic_coordinator/mpic_request_validator.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_request_validator.py
@@ -27,12 +27,6 @@ class MpicRequestValidator:
         return len(request_validation_issues) == 0, request_validation_issues
 
     @staticmethod
-    def are_requested_perspectives_valid(requested_perspective_codes, target_perspectives) -> bool:
-        # check if requested_perspectives is a subset of known_perspectives
-        target_perspective_codes = [perspective.code for perspective in target_perspectives]
-        return all(code in target_perspective_codes for code in requested_perspective_codes)
-
-    @staticmethod
     def is_requested_perspective_count_valid(requested_perspective_count, target_perspectives) -> bool:
         # check if requested_perspective_count is an integer, at least 2, and at most the number of known_perspectives
         return isinstance(requested_perspective_count, int) and 2 <= requested_perspective_count <= len(target_perspectives)

--- a/src/open_mpic_core/mpic_coordinator/mpic_request_validator.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_request_validator.py
@@ -7,27 +7,13 @@ class MpicRequestValidator:
     @staticmethod
     # returns a list of validation issues found in the request; if empty, request is (probably) valid
     # TODO should we create a flag to validate values separately from structure?
-    def is_request_valid(mpic_request, known_perspectives, diagnostic_mode=False) -> (bool, list):
+    def is_request_valid(mpic_request, known_perspectives) -> (bool, list):
         request_validation_issues = []
 
-        # TODO extract into a validate_orchestration_parameters method...
-        # TODO align on this: if present, should 'perspectives' override 'perspective-count'? or conflict?
-        # 'perspectives' is allowed if 'diagnostic_mode' is True
-        # if 'diagnostic-mode' is false, 'perspectives' is not allowed
-        # enforce that only one of 'perspectives' or 'perspective-count' is present
         should_validate_quorum_count = False
         requested_perspective_count = 0
         if mpic_request.orchestration_parameters is not None:
-            if mpic_request.orchestration_parameters.perspectives is not None and diagnostic_mode:
-                requested_perspectives = mpic_request.orchestration_parameters.perspectives
-                requested_perspective_count = len(requested_perspectives)
-                if MpicRequestValidator.are_requested_perspectives_valid(requested_perspectives, known_perspectives):
-                    should_validate_quorum_count = True
-                else:
-                    request_validation_issues.append(MpicRequestValidationIssue(MpicRequestValidationMessages.INVALID_PERSPECTIVE_LIST))
-            elif mpic_request.orchestration_parameters.perspectives:
-                request_validation_issues.append(MpicRequestValidationIssue(MpicRequestValidationMessages.PERSPECTIVES_NOT_IN_DIAGNOSTIC_MODE))
-            elif mpic_request.orchestration_parameters.perspective_count is not None:
+            if mpic_request.orchestration_parameters.perspective_count is not None:
                 requested_perspective_count = mpic_request.orchestration_parameters.perspective_count
                 if MpicRequestValidator.is_requested_perspective_count_valid(requested_perspective_count, known_perspectives):
                     should_validate_quorum_count = True

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -102,8 +102,8 @@ class MpicDcvChecker:
 
         try:
             lookup = dns.resolver.resolve(name_to_resolve, dns_record_type)
+            response_code = lookup.response.rcode
             records_as_strings = []
-            records_as_base64 = []
             for response_answer in lookup.response.answer:
                 if response_answer.rdtype == dns_record_type:
                     for record_data in response_answer:
@@ -116,6 +116,7 @@ class MpicDcvChecker:
             dcv_check_response.check_passed = expected_dns_record_content in records_as_strings
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.details.records_seen = records_as_strings
+            dcv_check_response.details.response_code = response_code
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -29,6 +29,8 @@ class MpicDcvChecker:
                 return self.perform_dns_change_validation(dcv_request)
             case DcvValidationMethod.ACME_HTTP_01:
                 return self.perform_acme_http_01_validation(dcv_request)
+            case DcvValidationMethod.ACME_DNS_01:
+                return self.perform_acme_dns_01_validation(dcv_request)
 
     def perform_website_change_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target  # TODO optionally iterate up through the domain hierarchy

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -13,6 +13,9 @@ from open_mpic_core.common_domain.validation_error import MpicValidationError
 
 # noinspection PyUnusedLocal
 class MpicDcvChecker:
+    WELL_KNOWN_PKI_PATH = '.well-known/pki-validation'
+    WELL_KNOWN_ACME_PATH = '.well-known/acme-challenge'
+
     def __init__(self, perspective: RemotePerspective):
         self.perspective = perspective
         # TODO self.dns_resolver = dns.resolver.Resolver() -- set up a way to use Unbound here... maybe take a config?
@@ -28,7 +31,7 @@ class MpicDcvChecker:
         domain_or_ip_target = request.domain_or_ip_target  # TODO optionally iterate up through the domain hierarchy
         url_scheme = request.dcv_check_parameters.validation_details.url_scheme
         token_path = request.dcv_check_parameters.validation_details.http_token_path
-        token_url = f"{url_scheme}://{domain_or_ip_target}/{token_path}"  # noqa E501 (http)
+        token_url = f"{url_scheme}://{domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_PKI_PATH}/{token_path}"  # noqa E501 (http)
         expected_response_content = request.dcv_check_parameters.validation_details.challenge_value
 
         response = requests.get(token_url)

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -2,11 +2,11 @@ import base64
 import time
 import dns.resolver
 import requests
+import urllib3
 
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.check_response import DcvCheckResponse
-from open_mpic_core.common_domain.check_response_details import DcvDnsChangeResponseDetails, \
-    DcvWebsiteChangeResponseDetails, RedirectResponse
+from open_mpic_core.common_domain.check_response_details import RedirectResponse, DcvCheckResponseDetailsBuilder
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.common_domain.validation_error import MpicValidationError
@@ -27,6 +27,8 @@ class MpicDcvChecker:
                 return self.perform_website_change_validation(dcv_request)
             case DcvValidationMethod.DNS_CHANGE:
                 return self.perform_dns_change_validation(dcv_request)
+            case DcvValidationMethod.ACME_HTTP_01:
+                return self.perform_acme_http_01_validation(dcv_request)
 
     def perform_website_change_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target  # TODO optionally iterate up through the domain hierarchy
@@ -35,43 +37,11 @@ class MpicDcvChecker:
         token_url = f"{url_scheme}://{domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_PKI_PATH}/{token_path}"  # noqa E501 (http)
         expected_response_content = request.dcv_check_parameters.validation_details.challenge_value
 
-        dcv_check_response = DcvCheckResponse(
-            perspective_code=self.perspective.code,
-            check_passed=False,
-            timestamp_ns=None,
-            errors=None,
-            details=DcvWebsiteChangeResponseDetails(
-                response_status_code=None,
-                response_history=None,
-                response_page=None,
-            )
-        )
+        dcv_check_response = self.create_empty_check_response(DcvValidationMethod.WEBSITE_CHANGE_V2)
 
         try:
             response = requests.get(token_url, stream=True)  # FIXME should probably add a timeout here.. but how long?
-
-            content = response.raw.read(100)
-            decoded_content = content.decode('utf-8')
-            base64_encoded_content = base64.b64encode(content) if content is not None else None
-
-            response_history = None
-            if hasattr(response, 'history') and response.history is not None and len(response.history) > 0:
-                response_history = [
-                    RedirectResponse(status_code=resp.status_code, url=resp.headers['Location'])
-                    for resp in response.history
-                ]
-
-            dcv_check_response.timestamp_ns = time.time_ns()
-
-            if response.status_code == requests.codes.OK:
-                result = response.text.strip()
-                dcv_check_response.check_passed = (result == expected_response_content)
-                dcv_check_response.details.response_status_code = response.status_code
-                dcv_check_response.details.response_url = token_url
-                dcv_check_response.details.response_history = response_history
-                dcv_check_response.details.response_page = base64_encoded_content
-            else:
-                dcv_check_response.errors = [MpicValidationError(error_type=str(response.status_code), error_message=response.reason)]
+            MpicDcvChecker.evaluate_http_lookup_response(dcv_check_response, response, token_url, expected_response_content)
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
@@ -90,15 +60,7 @@ class MpicDcvChecker:
 
         # TODO add leading underscore to name_to_resolve if it's not found?
 
-        dcv_check_response = DcvCheckResponse(
-            perspective_code=self.perspective.code,
-            check_passed=False,
-            timestamp_ns=None,
-            errors=None,
-            details=DcvDnsChangeResponseDetails(
-                records_seen=None,
-            )
-        )
+        dcv_check_response = self.create_empty_check_response(DcvValidationMethod.DNS_CHANGE)
 
         try:
             lookup = dns.resolver.resolve(name_to_resolve, dns_record_type)
@@ -123,3 +85,58 @@ class MpicDcvChecker:
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
 
         return dcv_check_response
+
+    def perform_acme_http_01_validation(self, request) -> DcvCheckResponse:
+        domain_or_ip_target = request.domain_or_ip_target
+        token = request.dcv_check_parameters.validation_details.token
+        expected_response_content = request.dcv_check_parameters.validation_details.key_authorization
+        token_url = f"http://{domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_ACME_PATH}/{token}"  # noqa E501 (http)
+
+        dcv_check_response = self.create_empty_check_response(DcvValidationMethod.ACME_HTTP_01)
+
+        try:
+            urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
+            response = requests.get(url=token_url, verify=False)  # don't verify SSL so can follow redirects to HTTPS (correct?)
+            MpicDcvChecker.evaluate_http_lookup_response(dcv_check_response, response, token_url, expected_response_content)
+        except requests.exceptions.RequestException as e:
+            dcv_check_response.timestamp_ns = time.time_ns()
+            dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
+
+        return dcv_check_response
+
+    def create_empty_check_response(self, validation_method: DcvValidationMethod) -> DcvCheckResponse:
+        return DcvCheckResponse(
+            perspective_code=self.perspective.code,
+            check_passed=False,
+            timestamp_ns=None,
+            errors=None,
+            details=DcvCheckResponseDetailsBuilder.build_response_details(validation_method)
+        )
+
+    @staticmethod
+    def evaluate_http_lookup_response(dcv_check_response: DcvCheckResponse, lookup_response: requests.Response, target_url: str, challenge_value: str):
+        content = lookup_response.raw.read(100)
+        decoded_content = content.decode('utf-8')
+        base64_encoded_content = base64.b64encode(content) if content is not None else None
+
+        response_history = None
+        if hasattr(lookup_response, 'history') and lookup_response.history is not None and len(lookup_response.history) > 0:
+            response_history = [
+                RedirectResponse(status_code=resp.status_code, url=resp.headers['Location'])
+                for resp in lookup_response.history
+            ]
+
+        dcv_check_response.timestamp_ns = time.time_ns()
+
+        if lookup_response.status_code == requests.codes.OK:
+            result = lookup_response.text.strip()
+            expected_response_content = challenge_value
+            dcv_check_response.check_passed = (result == expected_response_content)
+            dcv_check_response.details.response_status_code = lookup_response.status_code
+            dcv_check_response.details.response_url = target_url
+            dcv_check_response.details.response_history = response_history
+            dcv_check_response.details.response_page = base64_encoded_content
+        else:
+            dcv_check_response.errors = [
+                MpicValidationError(error_type=str(lookup_response.status_code), error_message=lookup_response.reason)]
+            

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -4,6 +4,8 @@ import requests
 
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.check_response import DcvCheckResponse, DcvCheckResponseDetails
+from open_mpic_core.common_domain.check_response_details import DcvDnsChangeResponseDetails, \
+    DcvWebsiteChangeResponseDetails
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.common_domain.validation_error import MpicValidationError
@@ -36,7 +38,7 @@ class MpicDcvChecker:
                 perspective_code=self.perspective.code,
                 check_passed=(result == expected_response_content),
                 timestamp_ns=time.time_ns(),
-                details=DcvCheckResponseDetails()  # FIXME get details
+                details=DcvWebsiteChangeResponseDetails()  # FIXME get details
             )
         else:
             dcv_check_response = DcvCheckResponse(
@@ -44,7 +46,7 @@ class MpicDcvChecker:
                 check_passed=False,
                 timestamp_ns=time.time_ns(),
                 errors=[MpicValidationError(error_type=str(response.status_code), error_message=response.reason)],
-                details=DcvCheckResponseDetails()
+                details=DcvWebsiteChangeResponseDetails()
             )
 
         return dcv_check_response
@@ -79,7 +81,7 @@ class MpicDcvChecker:
                 perspective_code=self.perspective.code,
                 check_passed=expected_dns_record_content in records_as_strings,
                 timestamp_ns=time.time_ns(),
-                details=DcvCheckResponseDetails()  # FIXME get details (or don't bother with this)
+                details=DcvDnsChangeResponseDetails()  # FIXME get details (or don't bother with this)
             )
             return dcv_check_response
         except dns.exception.DNSException as e:
@@ -88,6 +90,6 @@ class MpicDcvChecker:
                 check_passed=False,
                 timestamp_ns=time.time_ns(),
                 errors=[MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)],
-                details=DcvCheckResponseDetails()
+                details=DcvDnsChangeResponseDetails()
             )
             return dcv_check_response

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -40,7 +40,7 @@ class MpicDcvChecker:
         dcv_check_response = self.create_empty_check_response(DcvValidationMethod.WEBSITE_CHANGE_V2)
 
         try:
-            response = requests.get(token_url, stream=True)  # FIXME should probably add a timeout here.. but how long?
+            response = requests.get(url=token_url, stream=True)  # FIXME should probably add a timeout here.. but how long?
             MpicDcvChecker.evaluate_http_lookup_response(dcv_check_response, response, token_url, expected_response_content)
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -112,11 +112,10 @@ class MpicDcvChecker:
                         if record_data_as_string[0] == '"' and record_data_as_string[-1] == '"':
                             record_data_as_string = record_data_as_string[1:-1]
                         records_as_strings.append(record_data_as_string)
-                        records_as_base64.append(base64.b64encode(record_data_as_string.encode('utf-8')))
 
             dcv_check_response.check_passed = expected_dns_record_content in records_as_strings
             dcv_check_response.timestamp_ns = time.time_ns()
-            dcv_check_response.details.records_seen = records_as_base64
+            dcv_check_response.details.records_seen = records_as_strings
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -139,4 +139,3 @@ class MpicDcvChecker:
         else:
             dcv_check_response.errors = [
                 MpicValidationError(error_type=str(lookup_response.status_code), error_message=lookup_response.reason)]
-            

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -16,15 +16,16 @@ class MpicDcvChecker:
 
     def check_dcv(self, dcv_request: DcvCheckRequest) -> DcvCheckResponse:
         match dcv_request.dcv_check_parameters.validation_details.validation_method:
-            case DcvValidationMethod.HTTP_GENERIC:
-                return self.perform_http_validation(dcv_request)
-            case DcvValidationMethod.DNS_GENERIC:
-                return self.perform_dns_validation(dcv_request)
+            case DcvValidationMethod.WEBSITE_CHANGE_V2:
+                return self.perform_website_change_validation(dcv_request)
+            case DcvValidationMethod.DNS_CHANGE:
+                return self.perform_dns_change_validation(dcv_request)
 
-    def perform_http_validation(self, request) -> DcvCheckResponse:
+    def perform_website_change_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target  # TODO optionally iterate up through the domain hierarchy
+        url_scheme = request.dcv_check_parameters.validation_details.url_scheme
         token_path = request.dcv_check_parameters.validation_details.http_token_path
-        token_url = f"http://{domain_or_ip_target}/{token_path}"  # noqa E501 (http)
+        token_url = f"{url_scheme}://{domain_or_ip_target}/{token_path}"  # noqa E501 (http)
         expected_response_content = request.dcv_check_parameters.validation_details.challenge_value
 
         response = requests.get(token_url)
@@ -48,7 +49,7 @@ class MpicDcvChecker:
 
         return dcv_check_response
 
-    def perform_dns_validation(self, request) -> DcvCheckResponse:
+    def perform_dns_change_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target
         dns_name_prefix = request.dcv_check_parameters.validation_details.dns_name_prefix
         dns_record_type = dns.rdatatype.from_text(request.dcv_check_parameters.validation_details.dns_record_type)

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -117,6 +117,7 @@ class MpicDcvChecker:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.details.records_seen = records_as_strings
             dcv_check_response.details.response_code = response_code
+            dcv_check_response.details.ad_flag = lookup.response.flags & dns.flags.AD == dns.flags.AD  # single ampersand
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -15,6 +15,7 @@ from open_mpic_core.common_domain.validation_error import MpicValidationError
 class MpicDcvChecker:
     def __init__(self, perspective: RemotePerspective):
         self.perspective = perspective
+        # TODO self.dns_resolver = dns.resolver.Resolver() -- set up a way to use Unbound here... maybe take a config?
 
     def check_dcv(self, dcv_request: DcvCheckRequest) -> DcvCheckResponse:
         match dcv_request.dcv_check_parameters.validation_details.validation_method:
@@ -38,7 +39,10 @@ class MpicDcvChecker:
                 perspective_code=self.perspective.code,
                 check_passed=(result == expected_response_content),
                 timestamp_ns=time.time_ns(),
-                details=DcvWebsiteChangeResponseDetails()  # FIXME get details
+                details=DcvWebsiteChangeResponseDetails(
+                    response_status_code=response.status_code,
+                    response_url=token_url
+                ),
             )
         else:
             dcv_check_response = DcvCheckResponse(

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -116,8 +116,6 @@ class MpicDcvChecker:
     @staticmethod
     def evaluate_http_lookup_response(dcv_check_response: DcvCheckResponse, lookup_response: requests.Response, target_url: str, challenge_value: str):
         content = lookup_response.raw.read(100)
-        decoded_content = content.decode('utf-8')
-        base64_encoded_content = base64.b64encode(content) if content is not None else None
 
         response_history = None
         if hasattr(lookup_response, 'history') and lookup_response.history is not None and len(lookup_response.history) > 0:
@@ -135,7 +133,7 @@ class MpicDcvChecker:
             dcv_check_response.details.response_status_code = lookup_response.status_code
             dcv_check_response.details.response_url = target_url
             dcv_check_response.details.response_history = response_history
-            dcv_check_response.details.response_page = base64_encoded_content
+            dcv_check_response.details.response_page = content
         else:
             dcv_check_response.errors = [
                 MpicValidationError(error_type=str(lookup_response.status_code), error_message=lookup_response.reason)]

--- a/tests/integration/test_dcv_checker_with_resolver.py
+++ b/tests/integration/test_dcv_checker_with_resolver.py
@@ -1,0 +1,17 @@
+import pytest
+
+from open_mpic_core.common_domain.remote_perspective import RemotePerspective
+from open_mpic_core.mpic_dcv_checker.mpic_dcv_checker import MpicDcvChecker
+
+
+# noinspection PyMethodMayBeStatic
+@pytest.mark.integration
+class TestDcvCheckerWithResolver:
+    @classmethod
+    def setup_class(cls):
+        perspective: RemotePerspective = RemotePerspective(rir='arin', code='us-east-4')
+        cls.dcv_checker: MpicDcvChecker = MpicDcvChecker(perspective)
+
+    @pytest.mark.skip(reason='Not implemented yet')
+    def dcv_check__should_follow_redirects_and_return_list_in_response_details(self):
+        pass

--- a/tests/unit/open_mpic_core/test_mpic_caa_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_caa_request.py
@@ -18,14 +18,14 @@ class TestMpicCaaRequest:
         mpic_request = MpicCaaRequest.model_validate_json(json.dumps(request.model_dump()))
         assert mpic_request.domain_or_ip_target == request.domain_or_ip_target
 
-    def model_validate_json__should_throw_validation_error_given_missing_domain_or_ip_target(self):
+    def mpic_caa_request__should_require_domain_or_ip_target(self):
         request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         request.domain_or_ip_target = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicCaaRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'domain_or_ip_target' in str(validation_error.value)
 
-    def model_validate_json_should_throw_validation_error_given_invalid_certificate_type(self):
+    def mpic_caa_request__should_require_valid_certificate_type(self):
         request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         request.caa_check_parameters.certificate_type = 'invalid'
         with pytest.raises(pydantic.ValidationError) as validation_error:

--- a/tests/unit/open_mpic_core/test_mpic_coordinator.py
+++ b/tests/unit/open_mpic_core/test_mpic_coordinator.py
@@ -60,7 +60,7 @@ class TestMpicCoordinator:
         assert len(call_list) == 6
         assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.CAA}  # ensure each call is of type 'caa'
 
-    def collect_async_calls_to_issue__should_include_caa_check_parameters_as_caa_params_in_input_args_if_present(self):
+    def collect_async_calls_to_issue__should_include_caa_check_parameters_if_present(self):
         request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         request.caa_check_parameters.caa_domains = ['example.com']
         mpic_coordinator_config = self.create_mpic_coordinator_configuration()
@@ -68,7 +68,7 @@ class TestMpicCoordinator:
         call_list = MpicCoordinator.collect_async_calls_to_issue(request, target_perspectives)
         assert all(call.check_request.caa_check_parameters.caa_domains == ['example.com'] for call in call_list)
 
-    def collect_async_calls_to_issue__should_have_only_dcv_calls_and_include_validation_input_args_given_dcv_check_type(self):
+    def collect_async_calls_to_issue__should_have_only_dcv_calls_and_include_validation_details_given_dcv_check_type(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         mpic_coordinator_config = self.create_mpic_coordinator_configuration()
         target_perspectives = mpic_coordinator_config.target_perspectives
@@ -99,14 +99,14 @@ class TestMpicCoordinator:
             check_request = call_args[2]  # was previously a serialized string; now the actual CheckRequest object
             assert check_request.domain_or_ip_target == mpic_request.domain_or_ip_target
 
-    def coordinate_mpic__should_return_200_and_results_given_successful_caa_corroboration(self):
+    def coordinate_mpic__should_return_check_success_given_successful_caa_corroboration(self):
         mpic_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         mpic_coordinator_config = self.create_mpic_coordinator_configuration()
         mpic_coordinator = MpicCoordinator(self.create_successful_remote_caa_check_response, mpic_coordinator_config)
         mpic_response = mpic_coordinator.coordinate_mpic(mpic_request)
         assert mpic_response.is_valid is True
 
-    def coordinate_mpic__should_successfully_carry_out_caa_mpic_given_no_parameters_besides_target(self):
+    def coordinate_mpic__should_fully_carry_out_caa_mpic_given_no_parameters_besides_target(self):
         mpic_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         mpic_request.orchestration_parameters = None
         mpic_request.caa_check_parameters = None
@@ -115,7 +115,7 @@ class TestMpicCoordinator:
         mpic_response = mpic_coordinator.coordinate_mpic(mpic_request)
         assert mpic_response.is_valid is True
 
-    def coordinate_mpic__should_successfully_carry_out_caa_mpic_given_empty_orchestration_parameters(self):
+    def coordinate_mpic__should_fully_carry_out_caa_mpic_given_empty_orchestration_parameters(self):
         mpic_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         mpic_request.orchestration_parameters = MpicRequestOrchestrationParameters()
         mpic_request.caa_check_parameters = None
@@ -124,7 +124,7 @@ class TestMpicCoordinator:
         mpic_response = mpic_coordinator.coordinate_mpic(mpic_request)
         assert mpic_response.is_valid is True
 
-    def coordinate_mpic__should_successfully_carry_out_caa_mpic_given_only_max_attempts_orchestration_parameters(self):
+    def coordinate_mpic__should_fully_carry_out_caa_mpic_given_only_max_attempts_orchestration_parameter(self):
         mpic_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         # Reset all fields in orchestration parameters to None
         mpic_request.orchestration_parameters = MpicRequestOrchestrationParameters()
@@ -202,7 +202,7 @@ class TestMpicCoordinator:
         # assert that perspectives in first cohort and in second cohort are the same perspectives
         assert all(first_cohort_sorted[i].perspective_code == second_cohort_sorted[i].perspective_code for i in range(len(first_cohort_sorted)))
 
-    def coordinate_mpic__should_cap_attempts_at_max_attempts_env_parameter_if_found(self):
+    def coordinate_mpic__should_cap_attempts_at_max_attempts_if_configured(self):
         mpic_coordinator_configuration = self.create_mpic_coordinator_configuration()
         mpic_coordinator_configuration.global_max_attempts = 2
         mpic_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()

--- a/tests/unit/open_mpic_core/test_mpic_coordinator.py
+++ b/tests/unit/open_mpic_core/test_mpic_coordinator.py
@@ -275,8 +275,8 @@ class TestMpicCoordinator:
         mpic_coordinator_configuration = MpicCoordinatorConfiguration(
             target_perspectives,
             default_perspective_count,
-            enforce_distinct_rir_regions, 
-            global_max_attempts, 
+            enforce_distinct_rir_regions,
+            global_max_attempts,
             hash_secret)
         return mpic_coordinator_configuration
 

--- a/tests/unit/open_mpic_core/test_mpic_coordinator.py
+++ b/tests/unit/open_mpic_core/test_mpic_coordinator.py
@@ -69,13 +69,13 @@ class TestMpicCoordinator:
         assert all(call.check_request.caa_check_parameters.caa_domains == ['example.com'] for call in call_list)
 
     def collect_async_calls_to_issue__should_have_only_dcv_calls_and_include_validation_input_args_given_dcv_check_type(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_GENERIC)
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         mpic_coordinator_config = self.create_mpic_coordinator_configuration()
         target_perspectives = mpic_coordinator_config.target_perspectives
         call_list = MpicCoordinator.collect_async_calls_to_issue(request, target_perspectives)
         assert len(call_list) == 6
         assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.DCV}  # ensure each call is of type 'dcv'
-        assert all(call.check_request.dcv_check_parameters.validation_details.validation_method == DcvValidationMethod.DNS_GENERIC for call in call_list)
+        assert all(call.check_request.dcv_check_parameters.validation_details.validation_method == DcvValidationMethod.DNS_CHANGE for call in call_list)
         assert all(call.check_request.dcv_check_parameters.validation_details.dns_name_prefix == 'test' for call in call_list)
 
     def coordinate_mpic__should_call_remote_perspective_call_function_with_correct_parameters(self):

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -59,7 +59,7 @@ class TestMpicDcvChecker:
         url_scheme = dcv_request.dcv_check_parameters.validation_details.url_scheme
         http_token_path = dcv_request.dcv_check_parameters.validation_details.http_token_path
         expected_response_details = DcvWebsiteChangeResponseDetails(
-            response_url=f"{url_scheme}://{dcv_request.domain_or_ip_target}/{http_token_path}",
+            response_url=f"{url_scheme}://{dcv_request.domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_PKI_PATH}/{http_token_path}",
             response_status_code=200
         )
         assert dcv_response.timestamp_ns is not None
@@ -75,7 +75,6 @@ class TestMpicDcvChecker:
         assert dcv_response.check_passed is False
         assert dcv_response.errors == errors
 
-    @pytest.mark.skip(reason='Not yet implemented')
     def perform_website_change_validation__should_auto_insert_well_known_path_segment(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.validation_details.http_token_path = 'test-path'
@@ -83,7 +82,7 @@ class TestMpicDcvChecker:
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_website_change_validation(dcv_request)
         url_scheme = dcv_request.dcv_check_parameters.validation_details.url_scheme
-        expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/.well-known/pki_validation/test-path"
+        expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/.well-known/pki-validation/test-path"
         assert dcv_response.details.response_url == expected_url
 
     @pytest.mark.parametrize('url_scheme', ['http', 'https'])
@@ -128,7 +127,7 @@ class TestMpicDcvChecker:
     def mock_website_change_related_calls(self, dcv_request: DcvCheckRequest, mocker):
         url_scheme = dcv_request.dcv_check_parameters.validation_details.url_scheme
         http_token_path = dcv_request.dcv_check_parameters.validation_details.http_token_path
-        expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/{http_token_path}"
+        expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_PKI_PATH}/{http_token_path}"
         expected_challenge = dcv_request.dcv_check_parameters.validation_details.challenge_value
         mocker.patch('requests.get', side_effect=lambda url: (
             type('Response', (object,), {'status_code': 200, 'text': expected_challenge})() if url == expected_url else

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -177,8 +177,7 @@ class TestMpicDcvChecker:
         assert dcv_response.timestamp_ns is not None
         expected_value_1 = dcv_request.dcv_check_parameters.validation_details.challenge_value
         expected_records = [expected_value_1, 'whatever2', 'whatever3']
-        expected_records_as_base64 = [base64.b64encode(record.encode('utf-8')) for record in expected_records]
-        assert dcv_response.details.records_seen == expected_records_as_base64
+        assert dcv_response.details.records_seen == expected_records
 
     def perform_dns_change_validation__should_return_check_failure_with_errors_given_expected_dns_record_not_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -67,7 +67,7 @@ class TestMpicDcvChecker:
         assert dcv_response.check_passed is True
 
     @pytest.mark.skip('this is just for local debugging...')  # FIXME delete this before long
-    def foo__should_be_good(self, set_env_variables):
+    def delete_me__this_is_used_for_local_debugging_for_now(self, set_env_variables):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.domain_or_ip_target = 'sectigo.com'  # 404: 'https://blog.fluidui.com/moomoomoo'
         dcv_request.dcv_check_parameters.validation_details.url_scheme = 'https'
@@ -75,7 +75,7 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is True
 
-    def perform_website_change_validation__should_return_check_passed_true_given_request_token_file_found(self, set_env_variables, mocker):
+    def perform_website_change_validation__should_return_check_success_given_request_token_file_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         self.mock_website_change_related_calls(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
@@ -93,7 +93,7 @@ class TestMpicDcvChecker:
         assert dcv_response.details.response_url == f"{url_scheme}://{dcv_request.domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_PKI_PATH}/{http_token_path}"
         assert dcv_response.details.response_status_code == 200
 
-    def perform_website_change_validation__should_return_check_passed_false_given_request_token_file_not_found(self, set_env_variables, mocker):
+    def perform_website_change_validation__should_return_check_failure_given_request_token_file_not_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         fail_response = TestMpicDcvChecker.create_mock_response(404, 'Not Found', {'reason': 'Not Found'})
         mocker.patch('requests.get', return_value=fail_response)
@@ -112,7 +112,7 @@ class TestMpicDcvChecker:
         errors = [MpicValidationError(error_type='404', error_message='Not Found')]
         assert dcv_response.errors == errors
 
-    def perform_website_change_validation__should_return_check_failed_and_error_details_given_exception_raised(self, set_env_variables, mocker):
+    def perform_website_change_validation__should_return_check_failure_and_error_details_given_exception_raised(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         mocker.patch('requests.get', side_effect=lambda url, stream: self.raise_(RequestException('Test Exception')))
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -1,4 +1,3 @@
-import base64
 from io import BytesIO
 from unittest.mock import MagicMock
 
@@ -258,6 +257,13 @@ class TestMpicDcvChecker:
         self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        assert dcv_response.check_passed is True
+
+    def perform_acme_dns_validation__should_return_check_success_given_expected_dns_record_found(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_dns_01_check_request()
+        self.mock_dns_resolve_call(dcv_request, mocker)
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_acme_dns_01_validation(dcv_request)
         assert dcv_response.check_passed is True
 
     def perform_dns_change_validation__should_return_check_failure_given_non_matching_dns_record(self, set_env_variables, mocker):

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -2,6 +2,8 @@ import dns
 import pytest
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.check_response import DcvCheckResponse, DcvCheckResponseDetails
+from open_mpic_core.common_domain.check_response_details import DcvDnsChangeResponseDetails, \
+    DcvWebsiteChangeResponseDetails
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
@@ -37,16 +39,19 @@ class TestMpicDcvChecker:
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CNAME)])
     def check_dcv__should_perform_appropriate_check_and_return_200_and_allow_issuance_given_target_record_found(self, set_env_variables, validation_method, record_type, mocker):
         dcv_request = None
+        response_details = None
         match validation_method:
             case DcvValidationMethod.WEBSITE_CHANGE_V2:
                 dcv_request = ValidCheckCreator.create_valid_http_check_request()
                 self.mock_website_change_related_calls(dcv_request, mocker)
+                response_details = DcvWebsiteChangeResponseDetails()
             case DcvValidationMethod.DNS_CHANGE:
                 dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
                 self.mock_dns_related_calls(dcv_request, mocker)
+                response_details = DcvDnsChangeResponseDetails()
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.check_dcv(dcv_request)
-        assert self.is_result_as_expected(dcv_response, True, DcvCheckResponseDetails())
+        assert self.is_result_as_expected(dcv_response, True, response_details)
 
     def perform_website_change_validation__should_return_check_passed_true_with_details_given_request_token_file_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
@@ -54,7 +59,7 @@ class TestMpicDcvChecker:
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_website_change_validation(dcv_request)
         assert dcv_response.timestamp_ns is not None
-        assert self.is_result_as_expected(dcv_response, True, DcvCheckResponseDetails())
+        assert self.is_result_as_expected(dcv_response, True, DcvWebsiteChangeResponseDetails())
 
     def perform_website_change_validation__should_return_check_passed_false_with_details_given_request_token_file_not_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
@@ -63,7 +68,16 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.perform_website_change_validation(dcv_request)
         assert dcv_response.timestamp_ns is not None
         errors = [MpicValidationError(error_type='404', error_message='Not Found')]
-        assert self.is_result_as_expected(dcv_response, False, DcvCheckResponseDetails(), errors)
+        assert self.is_result_as_expected(dcv_response, False, DcvWebsiteChangeResponseDetails(), errors)
+
+    @pytest.mark.skip(reason='Not yet implemented')
+    def perform_website_change_validation__should_auto_insert_path_segment(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_http_check_request()
+        dcv_request.dcv_check_parameters.validation_details.http_token_path = 'test-path'
+        self.mock_website_change_related_calls(dcv_request, mocker)
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_website_change_validation(dcv_request)
+        assert self.is_result_as_expected(dcv_response, True, DcvWebsiteChangeResponseDetails())
 
     @pytest.mark.parametrize('url_scheme', ['http', 'https'])
     def perform_website_change_validation__should_use_specified_url_scheme(self, set_env_variables, url_scheme, mocker):
@@ -73,7 +87,7 @@ class TestMpicDcvChecker:
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_website_change_validation(dcv_request)
         # response should have been successful if expected URL was correctly put together
-        assert self.is_result_as_expected(dcv_response, True, DcvCheckResponseDetails())
+        assert self.is_result_as_expected(dcv_response, True, DcvWebsiteChangeResponseDetails())
 
     @pytest.mark.parametrize('record_type', [DnsRecordType.TXT, DnsRecordType.CNAME])
     def perform_dns_change_validation__should_return_check_passed_true_with_details_given_expected_dns_record_found(self, set_env_variables, record_type, mocker):
@@ -82,7 +96,7 @@ class TestMpicDcvChecker:
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
         assert dcv_response.timestamp_ns is not None
-        assert self.is_result_as_expected(dcv_response, True, DcvCheckResponseDetails())
+        assert self.is_result_as_expected(dcv_response, True, DcvDnsChangeResponseDetails())
 
     def perform_dns_change_validation__should_return_check_passed_false_with_details_given_expected_dns_record_not_found(self, set_env_variables, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()
@@ -91,7 +105,7 @@ class TestMpicDcvChecker:
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
         errors = [MpicValidationError(error_type=no_answer_error.__class__.__name__, error_message=no_answer_error.msg)]
-        assert self.is_result_as_expected(dcv_response, False, DcvCheckResponseDetails(), errors)
+        assert self.is_result_as_expected(dcv_response, False, DcvDnsChangeResponseDetails(), errors)
 
     def raise_(self, ex):
         # noinspection PyUnusedLocal
@@ -100,8 +114,9 @@ class TestMpicDcvChecker:
         return _raise()
 
     def mock_website_change_related_calls(self, dcv_request: DcvCheckRequest, mocker):
-        protocol = dcv_request.dcv_check_parameters.validation_details.url_scheme
-        expected_url = f"{protocol}://{dcv_request.domain_or_ip_target}/{dcv_request.dcv_check_parameters.validation_details.http_token_path}"  # noqa E501 (http)
+        url_scheme = dcv_request.dcv_check_parameters.validation_details.url_scheme
+        http_token_path = dcv_request.dcv_check_parameters.validation_details.http_token_path
+        expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/{http_token_path}"
         expected_challenge = dcv_request.dcv_check_parameters.validation_details.challenge_value
         mocker.patch('requests.get', side_effect=lambda url: (
             type('Response', (object,), {'status_code': 200, 'text': expected_challenge})() if url == expected_url else

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -51,7 +51,8 @@ class TestMpicDcvChecker:
     # integration test of a sort -- only mocking dns methods rather than remaining class methods
     @pytest.mark.parametrize('validation_method, record_type', [(DcvValidationMethod.WEBSITE_CHANGE_V2, None),
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.TXT),
-                                                                (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CNAME)])
+                                                                (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CNAME),
+                                                                (DcvValidationMethod.ACME_HTTP_01, None)])
     def check_dcv__should_perform_appropriate_check_and_allow_issuance_given_target_record_found(self, set_env_variables, validation_method, record_type, mocker):
         dcv_request, response_details, expected_response = None, None, None
         match validation_method:
@@ -61,6 +62,9 @@ class TestMpicDcvChecker:
             case DcvValidationMethod.DNS_CHANGE:
                 dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
                 self.mock_dns_resolve_call(dcv_request, mocker)
+            case DcvValidationMethod.ACME_HTTP_01:
+                dcv_request = ValidCheckCreator.create_valid_acme_http_01_check_request()
+                self.mock_http_call_response(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -228,6 +228,14 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.perform_acme_http_01_validation(dcv_request)
         assert dcv_response.check_passed is True
 
+    def perform_acme_http_validation__should_return_check_failure_given_non_matching_response(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_http_01_check_request()
+        self.mock_acme_http_call_response(dcv_request, mocker)
+        dcv_request.dcv_check_parameters.validation_details.key_authorization = 'expecting-this-value-now-instead'
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_acme_http_01_validation(dcv_request)
+        assert dcv_response.check_passed is False
+
     def raise_(self, ex):
         # noinspection PyUnusedLocal
         def _raise(*args, **kwargs):

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -236,6 +236,15 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.perform_acme_http_01_validation(dcv_request)
         assert dcv_response.check_passed is False
 
+    def perform_acme_http_validation__should_return_check_failure_and_error_details_given_exception_raised(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_http_01_check_request()
+        mocker.patch('requests.get', side_effect=lambda url, verify: self.raise_(RequestException('Test Exception')))
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_acme_http_01_validation(dcv_request)
+        assert dcv_response.check_passed is False
+        errors = [MpicValidationError(error_type='RequestException', error_message='Test Exception')]
+        assert dcv_response.errors == errors
+
     def raise_(self, ex):
         # noinspection PyUnusedLocal
         def _raise(*args, **kwargs):

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -240,8 +240,7 @@ class TestMpicDcvChecker:
                 self.mock_website_change_validation_large_payload(mocker)
                 dcv_response = dcv_checker.perform_acme_http_01_validation(dcv_request)
         hundred_a_chars = b'a' * 100  # store 100 'a' characters in a byte array
-        expected_content = base64.b64encode(hundred_a_chars)  # is this correct?
-        assert dcv_response.details.response_page == expected_content
+        assert dcv_response.details.response_page == hundred_a_chars
 
     @pytest.mark.parametrize('url_scheme', ['http', 'https'])
     def website_change_v2_validation__should_use_specified_url_scheme(self, set_env_variables, url_scheme, mocker):

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -51,7 +51,8 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize('validation_method, record_type', [(DcvValidationMethod.WEBSITE_CHANGE_V2, None),
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.TXT),
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CNAME),
-                                                                (DcvValidationMethod.ACME_HTTP_01, None)])
+                                                                (DcvValidationMethod.ACME_HTTP_01, None),
+                                                                (DcvValidationMethod.ACME_DNS_01, None)])
     def check_dcv__should_perform_appropriate_check_and_allow_issuance_given_target_record_found(self, set_env_variables, validation_method, record_type, mocker):
         dcv_request, response_details, expected_response = None, None, None
         match validation_method:
@@ -64,6 +65,9 @@ class TestMpicDcvChecker:
             case DcvValidationMethod.ACME_HTTP_01:
                 dcv_request = ValidCheckCreator.create_valid_acme_http_01_check_request()
                 self.mock_http_call_response(dcv_request, mocker)
+            case DcvValidationMethod.ACME_DNS_01:
+                dcv_request = ValidCheckCreator.create_valid_acme_dns_01_check_request()
+                self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison

--- a/tests/unit/open_mpic_core/test_mpic_dcv_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_request.py
@@ -1,7 +1,6 @@
 import json
 import pydantic
 import pytest
-from setuptools.package_index import URL_SCHEME
 
 from open_mpic_core.common_domain.check_parameters import DcvWebsiteChangeValidationDetails
 from open_mpic_core.common_domain.enum.check_type import CheckType
@@ -22,17 +21,6 @@ class TestMpicDcvRequest:
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         mpic_request = MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert mpic_request.domain_or_ip_target == request.domain_or_ip_target
-
-    # TODO this is probably not a valid test given that perspectives are for diagnostics mode only
-    # it likely needs different logic overall
-    def model_validate_json__should_throw_validation_error_given_both_perspectives_and_perspective_count_present(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
-        request.orchestration_parameters.perspective_count = 1
-        request.orchestration_parameters.perspectives = ['test']
-        with pytest.raises(pydantic.ValidationError) as validation_error:
-            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
-        assert 'perspective_count' in str(validation_error.value)
-        assert 'perspectives' in str(validation_error.value)
 
     def model_validate_json__should_throw_validation_error_given_missing_dcv_check_parameters(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_request.py
@@ -67,21 +67,21 @@ class TestMpicDcvRequest:
         assert 'challenge_value' in str(validation_error.value)
 
     def model_validate_json__should_throw_validation_error_given_missing_prefix_for_dns_validation(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_GENERIC)
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_name_prefix = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dns_name_prefix' in str(validation_error.value)
 
     def model_validate_json__should_throw_validation_error_given_missing_record_type_for_dns_validation(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_GENERIC)
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_record_type = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dns_record_type' in str(validation_error.value)
 
     def model_validate_json__should_throw_validation_error_given_invalid_record_type_for_dns_validation(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_GENERIC)
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_record_type = 'invalid'
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump(warnings=False)))
@@ -89,7 +89,7 @@ class TestMpicDcvRequest:
         assert 'invalid' in str(validation_error.value)
 
     def model_validate_json__should_throw_validation_error_given_missing_token_path_for_http_validation(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.HTTP_GENERIC)
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.WEBSITE_CHANGE_V2)
         request.dcv_check_parameters.validation_details.http_token_path = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))

--- a/tests/unit/open_mpic_core/test_mpic_dcv_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_request.py
@@ -22,21 +22,28 @@ class TestMpicDcvRequest:
         mpic_request = MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert mpic_request.domain_or_ip_target == request.domain_or_ip_target
 
-    def model_validate_json__should_throw_validation_error_given_missing_dcv_check_parameters(self):
+    def mpic_dcv_request__should_require_dcv_check_parameters(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.dcv_check_parameters = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dcv_check_parameters' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_validation_method_in_validation_details(self):
+    def mpic_dcv_request__should_require_validation_details_in_check_parameters(self):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        request.dcv_check_parameters.validation_details = None
+        with pytest.raises(pydantic.ValidationError) as validation_error:
+            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
+        assert 'validation_details' in str(validation_error.value)
+
+    def mpic_dcv_request__should_require_validation_method_in_validation_details(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.dcv_check_parameters.validation_details.validation_method = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'validation_method' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_invalid_validation_method_in_validation_details(self):
+    def mpic_dcv_request__should_require_valid_validation_method_in_validation_details(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.dcv_check_parameters.validation_details.validation_method = 'invalid'
         with pytest.raises(pydantic.ValidationError) as validation_error:
@@ -44,35 +51,28 @@ class TestMpicDcvRequest:
         assert 'validation_method' in str(validation_error.value)
         assert 'invalid' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_validation_details(self):
-        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
-        request.dcv_check_parameters.validation_details = None
-        with pytest.raises(pydantic.ValidationError) as validation_error:
-            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
-        assert 'validation_details' in str(validation_error.value)
-
-    def model_validate_json__should_throw_validation_error_given_missing_challenge_value(self):
+    def mpic_dcv_request__should_require_challenge_value_in_validation_details(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.dcv_check_parameters.validation_details.challenge_value = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'challenge_value' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_prefix_for_dns_validation(self):
+    def mpic_dcv_request__should_require_dns_name_prefix_for_dns_change_validation(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_name_prefix = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dns_name_prefix' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_record_type_for_dns_validation(self):
+    def mpic_dcv_request__should_require_dns_record_type_for_dns_change_validation(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_record_type = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dns_record_type' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_invalid_record_type_for_dns_validation(self):
+    def mpic_dcv_request__should_require_valid_dns_record_type_for_dns_change_validation(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.DNS_CHANGE)
         request.dcv_check_parameters.validation_details.dns_record_type = 'invalid'
         with pytest.raises(pydantic.ValidationError) as validation_error:
@@ -80,12 +80,27 @@ class TestMpicDcvRequest:
         assert 'dns_record_type' in str(validation_error.value)
         assert 'invalid' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_token_path_for_http_validation(self):
+    def mpic_dcv_request__should_require_http_token_path_for_website_change_validation(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.WEBSITE_CHANGE_V2)
         request.dcv_check_parameters.validation_details.http_token_path = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'http_token_path' in str(validation_error.value)
+
+    def mpic_dcv_request__should_require_token_for_acme_http_01_validation(self):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.ACME_HTTP_01)
+        request.dcv_check_parameters.validation_details.token = None
+        with pytest.raises(pydantic.ValidationError) as validation_error:
+            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
+        assert 'token' in str(validation_error.value)
+
+    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.ACME_HTTP_01, DcvValidationMethod.ACME_DNS_01])
+    def mpic_dcv_request__should_require_key_authorization_for_acme_validations(self, validation_method):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(validation_method)
+        request.dcv_check_parameters.validation_details.key_authorization = None
+        with pytest.raises(pydantic.ValidationError) as validation_error:
+            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
+        assert 'key_authorization' in str(validation_error.value)
 
     def mpic_dcv_request__should_have_check_type_set_to_dcv(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_request.py
@@ -1,8 +1,12 @@
 import json
 import pydantic
 import pytest
+from setuptools.package_index import URL_SCHEME
+
+from open_mpic_core.common_domain.check_parameters import DcvWebsiteChangeValidationDetails
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
+from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicDcvRequest
 
 from unit.test_util.valid_mpic_request_creator import ValidMpicRequestCreator
@@ -99,6 +103,16 @@ class TestMpicDcvRequest:
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         mpic_request = MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert mpic_request.check_type == CheckType.DCV
+
+    def mpic_dcv_request__should_default_to_http_scheme_for_website_change_validation_given_no_scheme_specified(self):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(DcvValidationMethod.WEBSITE_CHANGE_V2)
+        request.dcv_check_parameters.validation_details = DcvWebsiteChangeValidationDetails(
+            validation_method=DcvValidationMethod.WEBSITE_CHANGE_V2,
+            challenge_value='test',
+            http_token_path='example-path'
+        )
+        mpic_request = MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
+        assert mpic_request.dcv_check_parameters.validation_details.url_scheme == UrlScheme.HTTP
 
 
 if __name__ == '__main__':

--- a/tests/unit/open_mpic_core/test_mpic_request_validator.py
+++ b/tests/unit/open_mpic_core/test_mpic_request_validator.py
@@ -52,7 +52,7 @@ class TestMpicRequestValidator:
         assert is_request_valid is False
         assert MpicRequestValidationMessages.PERSPECTIVES_NOT_IN_DIAGNOSTIC_MODE.key in [issue.issue_type for issue in validation_issues]
 
-    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC])
+    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.WEBSITE_CHANGE_V2])
     def is_request_valid__should_return_true_given_valid_dcv_check_request(self, validation_method):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(validation_method)
         is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives)

--- a/tests/unit/open_mpic_core/test_mpic_request_validator.py
+++ b/tests/unit/open_mpic_core/test_mpic_request_validator.py
@@ -26,15 +26,6 @@ class TestMpicRequestValidator:
         assert is_request_valid is True
         assert len(validation_issues) == 0
 
-    def is_request_valid__should_return_true_given_valid_caa_check_request_with_perspective_list_and_diagnostic_mode_true(self):
-        request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
-        known_perspective_codes = [perspective.code for perspective in self.known_perspectives]
-        request.orchestration_parameters.perspectives = known_perspective_codes[:6]
-        request.orchestration_parameters.perspective_count = None
-        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives, True)
-        assert is_request_valid is True
-        assert len(validation_issues) == 0
-
     def is_request_valid__should_return_true_given_valid_caa_check_without_orchestration_parameters_or_caa_check_details(self):
         request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
         request.orchestration_parameters = None
@@ -42,15 +33,6 @@ class TestMpicRequestValidator:
         is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives)
         assert is_request_valid is True
         assert len(validation_issues) == 0
-
-    def is_request_valid__should_return_false_and_message_given_caa_check_request_with_perspective_list_and_diagnostic_mode_false(self):
-        request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
-        known_perspective_codes = [perspective.code for perspective in self.known_perspectives]
-        request.orchestration_parameters.perspectives = known_perspective_codes[:6]
-        request.orchestration_parameters.perspective_count = None
-        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives, False)
-        assert is_request_valid is False
-        assert MpicRequestValidationMessages.PERSPECTIVES_NOT_IN_DIAGNOSTIC_MODE.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.WEBSITE_CHANGE_V2])
     def is_request_valid__should_return_true_given_valid_dcv_check_request(self, validation_method):
@@ -68,14 +50,6 @@ class TestMpicRequestValidator:
         assert MpicRequestValidationMessages.INVALID_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_perspective_count_issue = next(issue for issue in validation_issues if issue.issue_type == MpicRequestValidationMessages.INVALID_PERSPECTIVE_COUNT.key)
         assert str(perspective_count) in invalid_perspective_count_issue.message
-
-    def is_request_valid__should_return_false_and_message_given_invalid_perspective_list(self):
-        request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
-        request.orchestration_parameters.perspective_count = None
-        request.orchestration_parameters.perspectives = ['bad_p1', 'bad_p2', 'bad_p3', 'bad_p4', 'bad_p5', 'bad_p6']
-        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives, True)
-        assert is_request_valid is False
-        assert MpicRequestValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]
 
     # TODO should there be a more permissive validation (in diagnostic mode?) for quorum count?
     @pytest.mark.parametrize('quorum_count', [1, -1, 0, 10, 'abc', sys.maxsize+1])

--- a/tests/unit/open_mpic_core/test_mpic_response_builder.py
+++ b/tests/unit/open_mpic_core/test_mpic_response_builder.py
@@ -1,5 +1,6 @@
 import pytest
 from open_mpic_core.common_domain.check_response import CaaCheckResponse, DcvCheckResponse, CaaCheckResponseDetails, DcvCheckResponseDetails
+from open_mpic_core.common_domain.check_response_details import DcvDnsChangeResponseDetails
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from open_mpic_core.mpic_coordinator.mpic_response_builder import MpicResponseBuilder
 
@@ -21,13 +22,13 @@ class TestMpicResponseBuilder:
                     CaaCheckResponse(perspective_code='p6', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False))
                 ]
             case check_type.DCV:
-                responses = [  # 2 false
-                    DcvCheckResponse(perspective_code='p1', check_passed=True, details=DcvCheckResponseDetails()),
-                    DcvCheckResponse(perspective_code='p2', check_passed=True, details=DcvCheckResponseDetails()),
-                    DcvCheckResponse(perspective_code='p3', check_passed=True, details=DcvCheckResponseDetails()),
-                    DcvCheckResponse(perspective_code='p4', check_passed=True, details=DcvCheckResponseDetails()),
-                    DcvCheckResponse(perspective_code='p5', check_passed=False, details=DcvCheckResponseDetails()),
-                    DcvCheckResponse(perspective_code='p6', check_passed=False, details=DcvCheckResponseDetails())
+                responses = [  # 2 false, using DNS Change method since that's in the request the test builder creates
+                    DcvCheckResponse(perspective_code='p1', check_passed=True, details=DcvDnsChangeResponseDetails()),
+                    DcvCheckResponse(perspective_code='p2', check_passed=True, details=DcvDnsChangeResponseDetails()),
+                    DcvCheckResponse(perspective_code='p3', check_passed=True, details=DcvDnsChangeResponseDetails()),
+                    DcvCheckResponse(perspective_code='p4', check_passed=True, details=DcvDnsChangeResponseDetails()),
+                    DcvCheckResponse(perspective_code='p5', check_passed=False, details=DcvDnsChangeResponseDetails()),
+                    DcvCheckResponse(perspective_code='p6', check_passed=False, details=DcvDnsChangeResponseDetails())
                 ]
 
         return responses

--- a/tests/unit/open_mpic_core/test_mpic_response_builder.py
+++ b/tests/unit/open_mpic_core/test_mpic_response_builder.py
@@ -1,7 +1,8 @@
 import pytest
-from open_mpic_core.common_domain.check_response import CaaCheckResponse, DcvCheckResponse, CaaCheckResponseDetails, DcvCheckResponseDetails
-from open_mpic_core.common_domain.check_response_details import DcvDnsChangeResponseDetails
+from open_mpic_core.common_domain.check_response import CaaCheckResponse, DcvCheckResponse, CaaCheckResponseDetails
+from open_mpic_core.common_domain.check_response_details import DcvCheckResponseDetailsBuilder
 from open_mpic_core.common_domain.enum.check_type import CheckType
+from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.mpic_coordinator.mpic_response_builder import MpicResponseBuilder
 
 from unit.test_util.valid_mpic_request_creator import ValidMpicRequestCreator
@@ -9,38 +10,32 @@ from unit.test_util.valid_mpic_request_creator import ValidMpicRequestCreator
 
 class TestMpicResponseBuilder:
     @staticmethod
-    def create_perspective_responses_given_check_type(check_type=CheckType.DCV):
+    def create_perspective_responses_given_check_type(check_type=CheckType.DCV, validation_method=None):
         responses = {}
         match check_type:
             case check_type.CAA:
-                responses = [  # 1 false
-                    CaaCheckResponse(perspective_code='p1', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False)),
-                    CaaCheckResponse(perspective_code='p2', check_passed=False, details=CaaCheckResponseDetails(caa_record_present=False)),
-                    CaaCheckResponse(perspective_code='p3', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False)),
-                    CaaCheckResponse(perspective_code='p4', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False)),
-                    CaaCheckResponse(perspective_code='p5', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False)),
-                    CaaCheckResponse(perspective_code='p6', check_passed=True, details=CaaCheckResponseDetails(caa_record_present=False))
-                ]
+                # 1 false out of 6
+                perspective_status_map = {'p1': True, 'p2': False, 'p3': True, 'p4': True, 'p5': True, 'p6': True}
+                responses = list(map(lambda code: CaaCheckResponse(perspective_code=code, check_passed=perspective_status_map[code],
+                                                                   details=CaaCheckResponseDetails(caa_record_present=(not perspective_status_map[code]))),
+                                     perspective_status_map.keys()))
             case check_type.DCV:
-                responses = [  # 2 false, using DNS Change method since that's in the request the test builder creates
-                    DcvCheckResponse(perspective_code='p1', check_passed=True, details=DcvDnsChangeResponseDetails()),
-                    DcvCheckResponse(perspective_code='p2', check_passed=True, details=DcvDnsChangeResponseDetails()),
-                    DcvCheckResponse(perspective_code='p3', check_passed=True, details=DcvDnsChangeResponseDetails()),
-                    DcvCheckResponse(perspective_code='p4', check_passed=True, details=DcvDnsChangeResponseDetails()),
-                    DcvCheckResponse(perspective_code='p5', check_passed=False, details=DcvDnsChangeResponseDetails()),
-                    DcvCheckResponse(perspective_code='p6', check_passed=False, details=DcvDnsChangeResponseDetails())
-                ]
+                response_details = DcvCheckResponseDetailsBuilder.build_response_details(validation_method)
+                # 2 false out of 6
+                perspective_status_map = {'p1': True, 'p2': True, 'p3': True, 'p4': True, 'p5': False, 'p6': False}
+                responses = list(map(lambda code: DcvCheckResponse(perspective_code=code, check_passed=perspective_status_map[code], details=response_details),
+                                     perspective_status_map.keys()))
 
         return responses
 
-    @pytest.mark.parametrize('check_type, perspective_count, quorum_count, is_valid_result', [
-        (CheckType.CAA, 6, 4, True),
-        (CheckType.DCV, 6, 5, False),  # higher quorum count
+    @pytest.mark.parametrize('check_type, perspective_count, quorum_count, is_valid_result, validation_method', [
+        (CheckType.CAA, 6, 4, True, None),
+        (CheckType.DCV, 6, 5, False, DcvValidationMethod.DNS_CHANGE),  # higher quorum count
     ])
     def build_response__should_return_response_given_mpic_request_configuration_and_results(
-            self, check_type, perspective_count, quorum_count, is_valid_result):
-        perspective_responses = self.create_perspective_responses_given_check_type(check_type)
-        request = ValidMpicRequestCreator.create_valid_mpic_request(check_type)
+            self, check_type, perspective_count, quorum_count, is_valid_result, validation_method):
+        perspective_responses = self.create_perspective_responses_given_check_type(check_type, validation_method)
+        request = ValidMpicRequestCreator.create_valid_mpic_request(check_type, validation_method)
         mpic_response = MpicResponseBuilder.build_response(request, perspective_count, quorum_count, 2,
                                                            perspective_responses, is_valid_result)
         assert (mpic_response.request_orchestration_parameters.perspective_count ==
@@ -53,7 +48,7 @@ class TestMpicResponseBuilder:
 
     def build_response__should_include_validation_details_and_method_when_present_in_request_body(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
-        persp_responses_per_check_type = self.create_perspective_responses_given_check_type(CheckType.DCV)
+        persp_responses_per_check_type = self.create_perspective_responses_given_check_type(CheckType.DCV, DcvValidationMethod.DNS_CHANGE)
         mpic_response = MpicResponseBuilder.build_response(request, 6, 5, 1,
                                                            persp_responses_per_check_type, False)
         assert mpic_response.dcv_check_parameters.validation_details.challenge_value == request.dcv_check_parameters.validation_details.challenge_value

--- a/tests/unit/test_util/mock_dns_object_creator.py
+++ b/tests/unit/test_util/mock_dns_object_creator.py
@@ -17,6 +17,13 @@ class MockDnsObjectCreator:
         return test_rrset
 
     @staticmethod
+    def create_txt_rrset(*txt_records: CNAME):
+        test_rrset = RRset(name=dns.name.from_text('example.com'), rdclass=dns.rdataclass.IN, rdtype=dns.rdatatype.TXT)
+        for txt_record in txt_records:
+            test_rrset.add(txt_record)
+        return test_rrset
+
+    @staticmethod
     def create_caa_record(flags, tag, value):
         return MockDnsObjectCreator.create_record_by_type(DnsRecordType.CAA, {'flag': flags, 'tag': tag, 'value': value})
 
@@ -48,12 +55,8 @@ class MockDnsObjectCreator:
                 dns_record = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, record_data)
             case DnsRecordType.CAA:
                 dns_record = MockDnsObjectCreator.create_record_by_type(DnsRecordType.CAA, record_data)
-        good_response = dns.message.QueryMessage()
-        good_response.flags = Flag.QR | Flag.RD | Flag.RA
-        if (record_name_prefix is not None) and (record_name_prefix != ''):  # if there is a domain name prefix
-            dns_record_name = dns.name.from_text(f"{record_name_prefix}.{record_name}")  # domain name prefix + domain name
-        else:
-            dns_record_name = dns.name.from_text(record_name)
+        good_response = MockDnsObjectCreator.create_dns_query_message_with_question(record_name, record_name_prefix, record_type)
+        dns_record_name = good_response.question[0].name
         dns_record_type = dns.rdatatype.from_text(record_type)
         response_question_rrset = RRset(name=dns_record_name, rdclass=dns.rdataclass.IN, rdtype=dns_record_type)
         good_response.question = [response_question_rrset]
@@ -62,3 +65,24 @@ class MockDnsObjectCreator:
         good_response.answer = [response_answer_rrset]  # caa checker doesn't look here, but dcv checker does
         mocker.patch('dns.message.Message.find_rrset', return_value=response_answer_rrset)  # needed for Answer constructor to work
         return dns.resolver.Answer(qname=dns_record_name, rdtype=dns_record_type, rdclass=dns.rdataclass.IN, response=good_response)
+
+    @staticmethod
+    def create_dns_query_answer_with_multiple_txt_records(record_name, record_name_prefix, *txt_records, mocker):
+        good_response = MockDnsObjectCreator.create_dns_query_message_with_question(record_name, record_name_prefix, DnsRecordType.TXT)
+        dns_record_name = good_response.question[0].name
+        response_answer_rrset = MockDnsObjectCreator.create_txt_rrset(*txt_records)
+        good_response.answer = [response_answer_rrset]
+        mocker.patch('dns.message.Message.find_rrset', return_value=response_answer_rrset)
+        return dns.resolver.Answer(qname=dns_record_name, rdtype=dns.rdatatype.TXT, rdclass=dns.rdataclass.IN, response=good_response)
+
+    @staticmethod
+    def create_dns_query_message_with_question(record_name, record_name_prefix, record_type: DnsRecordType) -> dns.message.QueryMessage:
+        query_message = dns.message.QueryMessage()
+        query_message.flags = Flag.QR | Flag.RD | Flag.RA
+        if (record_name_prefix is not None) and (record_name_prefix != ''):
+            dns_record_name = dns.name.from_text(f"{record_name_prefix}.{record_name}")
+        else:
+            dns_record_name = dns.name.from_text(record_name)
+        response_question_rrset = RRset(name=dns_record_name, rdclass=dns.rdataclass.IN, rdtype=dns.rdatatype.from_text(record_type))
+        query_message.question = [response_question_rrset]
+        return query_message

--- a/tests/unit/test_util/mock_dns_object_creator.py
+++ b/tests/unit/test_util/mock_dns_object_creator.py
@@ -19,8 +19,8 @@ class MockDnsObjectCreator:
     @staticmethod
     def create_txt_rrset(*txt_records: CNAME):
         test_rrset = RRset(name=dns.name.from_text('example.com'), rdclass=dns.rdataclass.IN, rdtype=dns.rdatatype.TXT)
-        for txt_record in txt_records:
-            test_rrset.add(txt_record)
+        for cname_record in txt_records:
+            test_rrset.add(cname_record)
         return test_rrset
 
     @staticmethod

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,9 +1,6 @@
 from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvWebsiteChangeValidationDetails, \
-    DcvDnsChangeValidationDetails, CaaCheckParameters
+    DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
-from open_mpic_core.common_domain.check_response import DcvCheckResponse
-from open_mpic_core.common_domain.check_response_details import DcvWebsiteChangeResponseDetails, \
-    DcvDnsChangeResponseDetails
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
 from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
@@ -36,4 +33,14 @@ class ValidCheckCreator:
                                        dns_name_prefix='_dnsauth',
                                        dns_record_type=record_type,
                                        challenge_value=f"{record_type}_challenge_111.ca1.com.")
+                               ))
+
+    @staticmethod
+    def create_valid_acme_http_01_check_request():
+        return DcvCheckRequest(domain_or_ip_target='example.com',
+                               dcv_check_parameters=DcvCheckParameters(
+                                   validation_details=DcvAcmeHttp01ValidationDetails(
+                                       token='token111_ca1',
+                                       key_authorization='challenge_111',
+                                   )
                                ))

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,8 +1,9 @@
-from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvHttpGenericValidationDetails, \
-    DcvDnsGenericValidationDetails, CaaCheckParameters
+from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvWebsiteChangeValidationDetails, \
+    DcvDnsChangeValidationDetails, CaaCheckParameters
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
+from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 
 
 class ValidCheckCreator:
@@ -17,16 +18,18 @@ class ValidCheckCreator:
     def create_valid_http_check_request():
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
-                                   validation_details=DcvHttpGenericValidationDetails(
+                                   validation_details=DcvWebsiteChangeValidationDetails(
                                        http_token_path='/.well-known/pki_validation/token111_ca1.txt',
-                                       challenge_value='challenge_111')
+                                       challenge_value='challenge_111',
+                                       url_scheme=UrlScheme.HTTP
+                                   )
                                ))
 
     @staticmethod
     def create_valid_dns_check_request(record_type=DnsRecordType.TXT):
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
-                                   validation_details=DcvDnsGenericValidationDetails(
+                                   validation_details=DcvDnsChangeValidationDetails(
                                        dns_name_prefix='_dnsauth',
                                        dns_record_type=record_type,
                                        challenge_value=f"{record_type}_challenge_111.ca1.com.")

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,5 +1,5 @@
 from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvWebsiteChangeValidationDetails, \
-    DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails
+    DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails, DcvAcmeDns01ValidationDetails
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
@@ -41,6 +41,15 @@ class ValidCheckCreator:
                                dcv_check_parameters=DcvCheckParameters(
                                    validation_details=DcvAcmeHttp01ValidationDetails(
                                        token='token111_ca1',
-                                       key_authorization='challenge_111',
+                                       key_authorization='challenge_111'
+                                   )
+                               ))
+
+    @staticmethod
+    def create_valid_acme_dns_01_check_request():
+        return DcvCheckRequest(domain_or_ip_target='example.com',
+                               dcv_check_parameters=DcvCheckParameters(
+                                   validation_details=DcvAcmeDns01ValidationDetails(
+                                       key_authorization='challenge_111'
                                    )
                                ))

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -22,7 +22,7 @@ class ValidCheckCreator:
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
                                    validation_details=DcvWebsiteChangeValidationDetails(
-                                       http_token_path='/.well-known/pki_validation/token111_ca1.txt',
+                                       http_token_path='token111_ca1.txt',
                                        challenge_value='challenge_111',
                                        url_scheme=UrlScheme.HTTP
                                    )

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -2,6 +2,7 @@ from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, Dc
     DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails, DcvAcmeDns01ValidationDetails
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
+from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
 from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 
@@ -53,3 +54,15 @@ class ValidCheckCreator:
                                        key_authorization='challenge_111'
                                    )
                                ))
+
+    @staticmethod
+    def create_valid_dcv_check_request(validation_method: DcvValidationMethod, record_type=DnsRecordType.TXT):
+        match validation_method:
+            case DcvValidationMethod.WEBSITE_CHANGE_V2:
+                return ValidCheckCreator.create_valid_http_check_request()
+            case DcvValidationMethod.DNS_CHANGE:
+                return ValidCheckCreator.create_valid_dns_check_request(record_type)
+            case DcvValidationMethod.ACME_HTTP_01:
+                return ValidCheckCreator.create_valid_acme_http_01_check_request()
+            case DcvValidationMethod.ACME_DNS_01:
+                return ValidCheckCreator.create_valid_acme_dns_01_check_request()

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -37,29 +37,3 @@ class ValidCheckCreator:
                                        dns_record_type=record_type,
                                        challenge_value=f"{record_type}_challenge_111.ca1.com.")
                                ))
-
-    @staticmethod
-    def create_valid_http_check_request_and_response(perspective_code: str) -> tuple[DcvCheckRequest, DcvCheckResponse]:
-        request = ValidCheckCreator.create_valid_http_check_request()
-        url_scheme = request.dcv_check_parameters.validation_details.url_scheme
-        http_token_path = request.dcv_check_parameters.validation_details.http_token_path
-        domain_or_ip = request.domain_or_ip_target
-        response = DcvCheckResponse(
-            perspective_code=perspective_code,
-            check_passed=True,
-            details=DcvWebsiteChangeResponseDetails(
-                response_url=f"{url_scheme}://{domain_or_ip}/{http_token_path}",
-                response_status_code=200
-            )
-        )
-        return request, response
-
-    @staticmethod
-    def create_valid_dns_check_request_and_response(perspective_code: str, record_type=DnsRecordType.TXT) -> tuple[DcvCheckRequest, DcvCheckResponse]:
-        request = ValidCheckCreator.create_valid_dns_check_request(record_type)
-        response = DcvCheckResponse(
-            perspective_code=perspective_code,
-            check_passed=True,
-            details=DcvDnsChangeResponseDetails()
-        )
-        return request, response

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,6 +1,9 @@
 from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvWebsiteChangeValidationDetails, \
     DcvDnsChangeValidationDetails, CaaCheckParameters
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
+from open_mpic_core.common_domain.check_response import DcvCheckResponse
+from open_mpic_core.common_domain.check_response_details import DcvWebsiteChangeResponseDetails, \
+    DcvDnsChangeResponseDetails
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
 from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
@@ -34,3 +37,29 @@ class ValidCheckCreator:
                                        dns_record_type=record_type,
                                        challenge_value=f"{record_type}_challenge_111.ca1.com.")
                                ))
+
+    @staticmethod
+    def create_valid_http_check_request_and_response(perspective_code: str) -> tuple[DcvCheckRequest, DcvCheckResponse]:
+        request = ValidCheckCreator.create_valid_http_check_request()
+        url_scheme = request.dcv_check_parameters.validation_details.url_scheme
+        http_token_path = request.dcv_check_parameters.validation_details.http_token_path
+        domain_or_ip = request.domain_or_ip_target
+        response = DcvCheckResponse(
+            perspective_code=perspective_code,
+            check_passed=True,
+            details=DcvWebsiteChangeResponseDetails(
+                response_url=f"{url_scheme}://{domain_or_ip}/{http_token_path}",
+                response_status_code=200
+            )
+        )
+        return request, response
+
+    @staticmethod
+    def create_valid_dns_check_request_and_response(perspective_code: str, record_type=DnsRecordType.TXT) -> tuple[DcvCheckRequest, DcvCheckResponse]:
+        request = ValidCheckCreator.create_valid_dns_check_request(record_type)
+        response = DcvCheckResponse(
+            perspective_code=perspective_code,
+            check_passed=True,
+            details=DcvDnsChangeResponseDetails()
+        )
+        return request, response

--- a/tests/unit/test_util/valid_mpic_request_creator.py
+++ b/tests/unit/test_util/valid_mpic_request_creator.py
@@ -1,8 +1,9 @@
 from open_mpic_core.common_domain.check_parameters import CaaCheckParameters, DcvCheckParameters, \
-    DcvDnsGenericValidationDetails, DcvHttpGenericValidationDetails
+    DcvDnsChangeValidationDetails, DcvWebsiteChangeValidationDetails
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
+from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 from open_mpic_core.mpic_coordinator.domain.mpic_request import BaseMpicRequest
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicCaaRequest
@@ -14,15 +15,15 @@ class ValidMpicRequestCreator:
     @staticmethod
     def create_valid_caa_mpic_request() -> MpicCaaRequest:
         return MpicCaaRequest(
-            domain_or_ip_target='test',
+            domain_or_ip_target='test.example.com',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=6, quorum_count=4),
             caa_check_parameters=CaaCheckParameters(certificate_type=CertificateType.TLS_SERVER)
         )
 
     @staticmethod
-    def create_valid_dcv_mpic_request(validation_method=DcvValidationMethod.DNS_GENERIC) -> MpicDcvRequest:
+    def create_valid_dcv_mpic_request(validation_method=DcvValidationMethod.DNS_CHANGE) -> MpicDcvRequest:
         return MpicDcvRequest(
-            domain_or_ip_target='test',
+            domain_or_ip_target='test.example.com',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=6, quorum_count=4),
             dcv_check_parameters=DcvCheckParameters(
                 validation_details=ValidMpicRequestCreator.create_validation_details(validation_method)
@@ -41,8 +42,9 @@ class ValidMpicRequestCreator:
     def create_validation_details(cls, validation_method):
         validation_details = {}
         match validation_method:
-            case DcvValidationMethod.DNS_GENERIC:
-                validation_details = DcvDnsGenericValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
-            case DcvValidationMethod.HTTP_GENERIC:
-                validation_details = DcvHttpGenericValidationDetails(http_token_path='http://example.com', challenge_value='test')  # noqa E501 (http)
+            case DcvValidationMethod.DNS_CHANGE:
+                validation_details = DcvDnsChangeValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
+            case DcvValidationMethod.WEBSITE_CHANGE_V2:
+                validation_details = DcvWebsiteChangeValidationDetails(
+                    http_token_path='examplepath', challenge_value='test', protocol=UrlScheme.HTTP)  # noqa E501 (http)
         return validation_details

--- a/tests/unit/test_util/valid_mpic_request_creator.py
+++ b/tests/unit/test_util/valid_mpic_request_creator.py
@@ -1,5 +1,6 @@
 from open_mpic_core.common_domain.check_parameters import CaaCheckParameters, DcvCheckParameters, \
-    DcvDnsChangeValidationDetails, DcvWebsiteChangeValidationDetails
+    DcvDnsChangeValidationDetails, DcvWebsiteChangeValidationDetails, DcvAcmeDns01ValidationDetails, \
+    DcvAcmeHttp01ValidationDetails
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
@@ -47,4 +48,8 @@ class ValidMpicRequestCreator:
             case DcvValidationMethod.WEBSITE_CHANGE_V2:
                 validation_details = DcvWebsiteChangeValidationDetails(
                     http_token_path='examplepath', challenge_value='test', url_scheme=UrlScheme.HTTP)  # noqa E501 (http)
+            case DcvValidationMethod.ACME_HTTP_01:
+                validation_details = DcvAcmeHttp01ValidationDetails(token='test', key_authorization='test')
+            case DcvValidationMethod.ACME_DNS_01:
+                validation_details = DcvAcmeDns01ValidationDetails(key_authorization='test')
         return validation_details

--- a/tests/unit/test_util/valid_mpic_request_creator.py
+++ b/tests/unit/test_util/valid_mpic_request_creator.py
@@ -46,5 +46,5 @@ class ValidMpicRequestCreator:
                 validation_details = DcvDnsChangeValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
             case DcvValidationMethod.WEBSITE_CHANGE_V2:
                 validation_details = DcvWebsiteChangeValidationDetails(
-                    http_token_path='examplepath', challenge_value='test', protocol=UrlScheme.HTTP)  # noqa E501 (http)
+                    http_token_path='examplepath', challenge_value='test', url_scheme=UrlScheme.HTTP)  # noqa E501 (http)
         return validation_details

--- a/tests/unit/test_util/valid_mpic_request_creator.py
+++ b/tests/unit/test_util/valid_mpic_request_creator.py
@@ -31,15 +31,15 @@ class ValidMpicRequestCreator:
         )
 
     @staticmethod
-    def create_valid_mpic_request(check_type: CheckType) -> BaseMpicRequest:
+    def create_valid_mpic_request(check_type, validation_method=DcvValidationMethod.DNS_CHANGE) -> BaseMpicRequest:
         match check_type:
             case CheckType.CAA:
                 return ValidMpicRequestCreator.create_valid_caa_mpic_request()
             case CheckType.DCV:
-                return ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+                return ValidMpicRequestCreator.create_valid_dcv_mpic_request(validation_method)
 
     @classmethod
-    def create_validation_details(cls, validation_method):
+    def create_validation_details(cls, validation_method=DcvValidationMethod.DNS_CHANGE):
         validation_details = {}
         match validation_method:
             case DcvValidationMethod.DNS_CHANGE:


### PR DESCRIPTION
acme-http-01 and acme-dns-01 are now implemented.
All validation methods now return the details as in the API spec (well, the branch of the API spec we should merge at some point here). The only field I've not implemented (a nice-to-have, IMO) is `resolved_ip`.
`test_mpic_dcv_checker` tests are refactored to largely be parameterized to accommodate both HTTP checks (Website Change v2 and ACME) and both DNS checks (DNS Change and ACME) together in a single test, to save on copy-pasting and cut down on lines of code in general.
There's some complexity in the test setup as a result but it's worth it IMO if we ever need to tweak or add more tests and more validation methods.