### PR TITLE
Refactored unit tests for CAA

### DIFF
--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -34,6 +34,7 @@ class DcvWebsiteChangeValidationDetails(DcvValidationDetails):
 class DcvDnsChangeValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
     challenge_value: str
+    require_exact_match: bool = True
     dns_name_prefix: str
     dns_record_type: DnsRecordType
 

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -12,7 +12,7 @@ from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 class CaaCheckParameters(BaseModel):
     certificate_type: CertificateType | None = None
     caa_domains: list[str] | None = None
-
+    # contact_info_query: bool | False = False  # to accommodate email and phone based DCV that gets contact info from CAA records
 
 class DcvValidationDetails(BaseModel, ABC):
     validation_method: DcvValidationMethod

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -12,7 +12,8 @@ from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 class CaaCheckParameters(BaseModel):
     certificate_type: CertificateType | None = None
     caa_domains: list[str] | None = None
-    # contact_info_query: bool | False = False  # to accommodate email and phone based DCV that gets contact info from CAA records
+    # contact_info_query: bool | False = False  # to better accommodate email/phone based DCV using contact info in CAA
+
 
 class DcvValidationDetails(BaseModel, ABC):
     validation_method: DcvValidationMethod
@@ -46,8 +47,6 @@ class DcvAcmeHttp01ValidationDetails(DcvValidationDetails):
 class DcvAcmeDns01ValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.ACME_DNS_01] = DcvValidationMethod.ACME_DNS_01
     key_authorization: str
-# Please deploy a DNS TXT record under the name
-# _acme-challenge.<domain.com> with the following value:  667drNmQL3vX6bu8YZlgy0wKNBlCny8yrjF1lSaUndc
 
 
 class DcvCheckParameters(BaseModel):

--- a/src/open_mpic_core/common_domain/check_response.py
+++ b/src/open_mpic_core/common_domain/check_response.py
@@ -9,9 +9,9 @@ from typing_extensions import Annotated
 
 class BaseCheckResponse(BaseModel):
     perspective_code: str
-    check_passed: bool = False  # TODO rename to is_valid ?
+    check_passed: bool = False
     errors: list[MpicValidationError] | None = None
-    timestamp_ns: int | None = None  # TODO what do we name this field?
+    timestamp_ns: int | None = None
 
 
 class CaaCheckResponse(BaseCheckResponse):

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 
 
 class CaaCheckResponseDetails(BaseModel):
-    caa_record_present: bool = False  # TODO allow None to reflect potential error state; rename to just 'present'?
+    caa_record_present: bool | None = None  # TODO allow None to reflect potential error state; rename to just 'present'?
     found_at: str | None = None  # domain where CAA record was found  # FIXME set this properly
     response: str | None = None  # base64 format of DNS RRset of response to CAA query  # FIXME set this properly
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 class CaaCheckResponseDetails(BaseModel):
     caa_record_present: bool | None = None  # TODO allow None to reflect potential error state; rename to just 'present'?
     found_at: str | None = None  # domain where CAA record was found  # FIXME set this properly
-    response: str | None = None  # base64 format of DNS RRset of response to CAA query  # FIXME set this properly
+    records_seen: list[str] | None = None  # list of records found in DNS query
 
 
 class RedirectResponse(BaseModel):

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -46,7 +46,6 @@ class MpicDcvChecker:
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
-
         return dcv_check_response
 
     def perform_dns_change_validation(self, request) -> DcvCheckResponse:
@@ -67,7 +66,6 @@ class MpicDcvChecker:
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
-
         return dcv_check_response
 
     def perform_acme_http_01_validation(self, request) -> DcvCheckResponse:
@@ -84,7 +82,6 @@ class MpicDcvChecker:
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
-
         return dcv_check_response
 
     def perform_acme_dns_01_validation(self, request) -> DcvCheckResponse:
@@ -100,7 +97,6 @@ class MpicDcvChecker:
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
-
         return dcv_check_response
 
     def create_empty_check_response(self, validation_method: DcvValidationMethod) -> DcvCheckResponse:

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -209,6 +209,16 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
         assert dcv_response.check_passed is True
 
+    def dns_change_validation__should_allow_finding_expected_challenge_as_substring(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_CHANGE)
+        dcv_request.dcv_check_parameters.validation_details.challenge_value = 'extraStuffchallenge-valueMoreStuff'
+        self.mock_dns_resolve_call(dcv_request, mocker)
+        dcv_request.dcv_check_parameters.validation_details.challenge_value = 'challenge-value'
+        dcv_request.dcv_check_parameters.validation_details.require_exact_match = False
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        assert dcv_response.check_passed is True
+
     @pytest.mark.parametrize('dns_name_prefix', ['_dnsauth', '', None])
     def dns_change_validation__should_use_dns_name_prefix_if_provided(self, set_env_variables, dns_name_prefix, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -378,8 +378,8 @@ class TestMpicDcvChecker:
         txt_record_1 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, record_data)
         txt_record_2 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'whatever2'})
         txt_record_3 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'whatever3'})
-        test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer_with_multiple_txt_records(
-            dcv_request.domain_or_ip_target, record_name_prefix,
+        test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer_with_multiple_records(
+            dcv_request.domain_or_ip_target, record_name_prefix, DnsRecordType.TXT,
             *[txt_record_1, txt_record_2, txt_record_3], mocker=mocker
         )
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)


### PR DESCRIPTION
Polished CAA unit tests to make it clearer what logic is being covered. Tweaked response details slightly to include a list of records seen similar to what we do for DCV.

This will require a corresponding change in the API as well: `details.records_seen` for CAA instead of `details.response`