### PR TITLE
Update `rcode` to be invoked as a method

### DIFF
--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -139,7 +139,7 @@ class MpicDcvChecker:
 
     @staticmethod
     def evaluate_dns_lookup_response(dcv_check_response: DcvCheckResponse, lookup_response: dns.resolver.Answer, dns_record_type: RdataType, expected_dns_record_content: str):
-        response_code = lookup_response.response.rcode
+        response_code = lookup_response.response.rcode()
         records_as_strings = []
         for response_answer in lookup_response.response.answer:
             if response_answer.rdtype == dns_record_type:

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -358,7 +358,7 @@ class TestMpicDcvChecker:
 
     def mock_dns_resolve_call_with_specific_response_code(self, dcv_request: DcvCheckRequest, response_code, mocker):
         test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
-        test_dns_query_answer.response.rcode = response_code
+        test_dns_query_answer.response.rcode = lambda: response_code
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)
 
     def mock_dns_resolve_call_with_specific_flag(self, dcv_request: DcvCheckRequest, flag, mocker):


### PR DESCRIPTION
Requests like the following:

```
{
  "domain_or_ip_target": "ba3007f45d42d513b8d13e11cb3f7de6.test.dcv-inspector.com",
  "dcv_check_parameters": {
    "validation_details": {
      "validation_method": "dns-change",
      "challenge_value": "sample_expected_value",
      "dns_name_prefix": "_acme-challenge",
      "dns_record_type": "TXT"
    }
  }
}
```

Are failing during response serialization with the following error:

```
[ERROR] PydanticSerializationError: Unable to serialize unknown type: <class 'method'>
Traceback (most recent call last):
  File "/var/task/mpic_dcv_checker_lambda_function.py", line 46, in lambda_handler
    return get_handler().process_invocation(event)
  File "/var/task/mpic_dcv_checker_lambda_function.py", line 24, in process_invocation
    'body': dcv_response.model_dump_json()
  File "/opt/python/lib/python3.11/site-packages/pydantic/main.py", line 415, in model_dump_json
    return self.__pydantic_serializer__.to_json(
```

The root cause is that `dns.message.Message.rcode` (https://dnspython.readthedocs.io/en/latest/message-class.html#dns.message.Message.rcode) is being treated as an attribute when it is actually a method.