### PR TITLE
Support for more DCV methods

### DIFF
--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -34,6 +34,7 @@ class DcvWebsiteChangeValidationDetails(DcvValidationDetails):
 class DcvDnsChangeValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.DNS_CHANGE] = DcvValidationMethod.DNS_CHANGE
     challenge_value: str
+    require_exact_match: bool = True
     dns_name_prefix: str
     dns_record_type: DnsRecordType
 

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -12,7 +12,7 @@ from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 class CaaCheckParameters(BaseModel):
     certificate_type: CertificateType | None = None
     caa_domains: list[str] | None = None
-
+    # contact_info_query: bool | False = False  # to accommodate email and phone based DCV that gets contact info from CAA records
 
 class DcvValidationDetails(BaseModel, ABC):
     validation_method: DcvValidationMethod

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -12,7 +12,8 @@ from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 class CaaCheckParameters(BaseModel):
     certificate_type: CertificateType | None = None
     caa_domains: list[str] | None = None
-    # contact_info_query: bool | False = False  # to accommodate email and phone based DCV that gets contact info from CAA records
+    # contact_info_query: bool | False = False  # to better accommodate email/phone based DCV using contact info in CAA
+
 
 class DcvValidationDetails(BaseModel, ABC):
     validation_method: DcvValidationMethod
@@ -46,8 +47,6 @@ class DcvAcmeHttp01ValidationDetails(DcvValidationDetails):
 class DcvAcmeDns01ValidationDetails(DcvValidationDetails):
     validation_method: Literal[DcvValidationMethod.ACME_DNS_01] = DcvValidationMethod.ACME_DNS_01
     key_authorization: str
-# Please deploy a DNS TXT record under the name
-# _acme-challenge.<domain.com> with the following value:  667drNmQL3vX6bu8YZlgy0wKNBlCny8yrjF1lSaUndc
 
 
 class DcvCheckParameters(BaseModel):

--- a/src/open_mpic_core/common_domain/check_response.py
+++ b/src/open_mpic_core/common_domain/check_response.py
@@ -9,9 +9,9 @@ from typing_extensions import Annotated
 
 class BaseCheckResponse(BaseModel):
     perspective_code: str
-    check_passed: bool = False  # TODO rename to is_valid ?
+    check_passed: bool = False
     errors: list[MpicValidationError] | None = None
-    timestamp_ns: int | None = None  # TODO what do we name this field?
+    timestamp_ns: int | None = None
 
 
 class CaaCheckResponse(BaseCheckResponse):

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 
 
 class CaaCheckResponseDetails(BaseModel):
-    caa_record_present: bool = False  # TODO allow None to reflect potential error state; rename to just 'present'?
+    caa_record_present: bool | None = None  # TODO allow None to reflect potential error state; rename to just 'present'?
     found_at: str | None = None  # domain where CAA record was found  # FIXME set this properly
     response: str | None = None  # base64 format of DNS RRset of response to CAA query  # FIXME set this properly
 

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 class CaaCheckResponseDetails(BaseModel):
     caa_record_present: bool | None = None  # TODO allow None to reflect potential error state; rename to just 'present'?
     found_at: str | None = None  # domain where CAA record was found  # FIXME set this properly
-    response: str | None = None  # base64 format of DNS RRset of response to CAA query  # FIXME set this properly
+    records_seen: list[str] | None = None  # list of records found in DNS query
 
 
 class RedirectResponse(BaseModel):

--- a/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
+++ b/src/open_mpic_core/common_domain/enum/dcv_validation_method.py
@@ -3,7 +3,11 @@ from enum import StrEnum
 
 class DcvValidationMethod(StrEnum):
     WEBSITE_CHANGE_V2 = 'website-change-v2'
-    DNS_CHANGE = 'dns-change'
+    DNS_CHANGE = 'dns-change'  # CNAME, TXT, or CAA record
     ACME_HTTP_01 = 'acme-http-01'
-    ACME_DNS_01 = 'acme-dns-01'
+    ACME_DNS_01 = 'acme-dns-01'  # TXT record
+    CONTACT_EMAIL = 'contact-email'  # TXT or CAA record TODO implement; (do recursive lookup of CAA records)
+    CONTACT_PHONE = 'contact-phone'  # TXT or CAA record TODO implement; (do recursive lookup of CAA records)
+    IP_LOOKUP = 'ip-lookup'  # A or AAAA record TODO implement
     ACME_TLS_ALPN_01 = 'acme-tls-alpn-01'  # not implemented yet
+

--- a/src/open_mpic_core/mpic_caa_checker/mpic_caa_checker.py
+++ b/src/open_mpic_core/mpic_caa_checker/mpic_caa_checker.py
@@ -45,14 +45,12 @@ class MpicCaaChecker:
         rrset = None
         domain = dns.name.from_text(caa_request.domain_or_ip_target)
 
-        while domain != dns.name.root:  # should we stop at TLD / Public Suffix? (e.g., .com, .ac.uk)
+        while domain != dns.name.root:
             try:
                 lookup = dns.resolver.resolve(domain, dns.rdatatype.CAA)
-                print(f'Found a CAA record for {domain}! Response: {lookup.rrset.to_text()}')
                 rrset = lookup.rrset
                 break
             except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                print(f'No CAA record found for {domain}; trying parent domain...')
                 domain = domain.parent()
             except Exception:
                 raise MpicCaaLookupException

--- a/src/open_mpic_core/mpic_coordinator/messages/mpic_request_validation_messages.py
+++ b/src/open_mpic_core/mpic_coordinator/messages/mpic_request_validation_messages.py
@@ -2,14 +2,10 @@ from enum import Enum
 
 
 class MpicRequestValidationMessages(Enum):
-    UNSUPPORTED_REQUEST_PATH = ('unsupported-request-path', 'Unsupported request path: {0}')
-    PERSPECTIVES_WITH_PERSPECTIVE_COUNT = ('contains-both-perspectives-and-perspective-count', "Request contains both 'perspectives' and 'perspective-count'.")
     INVALID_PERSPECTIVE_COUNT = ('invalid-perspective-count', 'Invalid perspective count: {0}')
-    INVALID_PERSPECTIVE_LIST = ('invalid-perspective-list', 'Invalid perspective list specified.')
-    PERSPECTIVES_NOT_IN_DIAGNOSTIC_MODE = ('perspectives-not-in-diagnostic-mode', 'Explicitly listing perspectives is only allowed in diagnostics mode.')
     INVALID_QUORUM_COUNT = ('invalid-quorum-count', 'Invalid quorum count: {0}')
     INVALID_CERTIFICATE_TYPE = ('invalid-certificate-type', "Invalid 'certificate-type' specified: {0}")
-    INVALID_VALIDATION_METHOD = ('invalid-validation-method', "Invalid 'validation-method' specified: {0}")
+    INVALID_VALIDATION_METHOD_RECORD_TYPE_COMBINATION = ('invalid-validation-method-record-type-combination', 'Invalid validation method and record type combination: {0} and {1}')
     REQUEST_VALIDATION_FAILED = ('request-validation-failed', 'Request validation failed.')
 
     def __init__(self, key, message):

--- a/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_coordinator.py
@@ -7,8 +7,7 @@ import concurrent.futures
 from datetime import datetime
 import hashlib
 
-from open_mpic_core.common_domain.check_response import CaaCheckResponse, \
-    CaaCheckResponseDetails, DcvCheckResponse, DcvCheckResponseDetails
+from open_mpic_core.common_domain.check_response import CaaCheckResponse, CaaCheckResponseDetails, DcvCheckResponse
 from open_mpic_core.common_domain.check_request import CaaCheckRequest, DcvCheckRequest
 from open_mpic_core.common_domain.check_response_details import DcvCheckResponseDetailsBuilder
 from open_mpic_core.common_domain.validation_error import MpicValidationError

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -46,7 +46,6 @@ class MpicDcvChecker:
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
-
         return dcv_check_response
 
     def perform_dns_change_validation(self, request) -> DcvCheckResponse:
@@ -67,7 +66,6 @@ class MpicDcvChecker:
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
-
         return dcv_check_response
 
     def perform_acme_http_01_validation(self, request) -> DcvCheckResponse:
@@ -84,7 +82,6 @@ class MpicDcvChecker:
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
-
         return dcv_check_response
 
     def perform_acme_dns_01_validation(self, request) -> DcvCheckResponse:
@@ -100,7 +97,6 @@ class MpicDcvChecker:
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
-
         return dcv_check_response
 
     def create_empty_check_response(self, validation_method: DcvValidationMethod) -> DcvCheckResponse:

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -2,12 +2,12 @@ import time
 import dns.resolver
 import requests
 import urllib3
-from dns.rdatatype import RdataType
 
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.check_response import DcvCheckResponse
 from open_mpic_core.common_domain.check_response_details import RedirectResponse, DcvCheckResponseDetailsBuilder
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
+from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.common_domain.validation_error import MpicValidationError
 
@@ -16,6 +16,8 @@ from open_mpic_core.common_domain.validation_error import MpicValidationError
 class MpicDcvChecker:
     WELL_KNOWN_PKI_PATH = '.well-known/pki-validation'
     WELL_KNOWN_ACME_PATH = '.well-known/acme-challenge'
+    CONTACT_EMAIL_TAG = 'contactemail'
+    CONTACT_PHONE_TAG = 'contactphone'
 
     def __init__(self, perspective: RemotePerspective):
         self.perspective = perspective
@@ -25,12 +27,10 @@ class MpicDcvChecker:
         match dcv_request.dcv_check_parameters.validation_details.validation_method:
             case DcvValidationMethod.WEBSITE_CHANGE_V2:
                 return self.perform_website_change_validation(dcv_request)
-            case DcvValidationMethod.DNS_CHANGE:
-                return self.perform_dns_change_validation(dcv_request)
             case DcvValidationMethod.ACME_HTTP_01:
                 return self.perform_acme_http_01_validation(dcv_request)
-            case DcvValidationMethod.ACME_DNS_01:
-                return self.perform_acme_dns_01_validation(dcv_request)
+            case _:  # ACME_DNS_01 | DNS_CHANGE | IP_LOOKUP | CONTACT_EMAIL | CONTACT_PHONE
+                return self.perform_general_dns_validation(dcv_request)
 
     def perform_website_change_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target  # TODO optionally iterate up through the domain hierarchy
@@ -48,27 +48,56 @@ class MpicDcvChecker:
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
         return dcv_check_response
 
-    def perform_dns_change_validation(self, request) -> DcvCheckResponse:
-        domain_or_ip_target = request.domain_or_ip_target
-        dns_name_prefix = request.dcv_check_parameters.validation_details.dns_name_prefix
-        dns_record_type = dns.rdatatype.from_text(request.dcv_check_parameters.validation_details.dns_record_type)
+    def perform_general_dns_validation(self, request) -> DcvCheckResponse:
+        validation_details = request.dcv_check_parameters.validation_details
+        validation_method = validation_details.validation_method
+        dns_name_prefix = validation_details.dns_name_prefix
+        dns_record_type = validation_details.dns_record_type
+        exact_match = True
+
         if dns_name_prefix is not None and len(dns_name_prefix) > 0:
-            name_to_resolve = f"{dns_name_prefix}.{domain_or_ip_target}"
+            name_to_resolve = f"{dns_name_prefix}.{request.domain_or_ip_target}"
         else:
-            name_to_resolve = domain_or_ip_target
-        expected_dns_record_content = request.dcv_check_parameters.validation_details.challenge_value
-        exact_match = request.dcv_check_parameters.validation_details.require_exact_match
-        dcv_check_response = self.create_empty_check_response(DcvValidationMethod.DNS_CHANGE)
+            name_to_resolve = request.domain_or_ip_target
+
+        if validation_method == DcvValidationMethod.ACME_DNS_01:
+            expected_dns_record_content = validation_details.key_authorization
+        else:
+            expected_dns_record_content = validation_details.challenge_value
+            exact_match = validation_details.require_exact_match
+
+        dcv_check_response = self.create_empty_check_response(validation_method)
 
         try:
-            # TODO add leading underscore to name_to_resolve if it's not found?
-            lookup = dns.resolver.resolve(name_to_resolve, dns_record_type)
-            MpicDcvChecker.evaluate_dns_lookup_response(dcv_check_response, lookup, dns_record_type,
+            lookup = MpicDcvChecker.perform_dns_resolution(name_to_resolve, validation_method, dns_record_type)
+            MpicDcvChecker.evaluate_dns_lookup_response(dcv_check_response, lookup, validation_method, dns_record_type,
                                                         expected_dns_record_content, exact_match)
         except dns.exception.DNSException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
         return dcv_check_response
+
+    @staticmethod
+    def perform_dns_resolution(name_to_resolve, validation_method, dns_record_type):
+        walk_domain_tree = ((validation_method == DcvValidationMethod.CONTACT_EMAIL or
+                            validation_method == DcvValidationMethod.CONTACT_PHONE) and
+                            dns_record_type == DnsRecordType.CAA)
+
+        dns_rdata_type = dns.rdatatype.from_text(dns_record_type)
+        lookup = None
+        # walk_domain_tree = False  # TODO remove this and test logic
+        if walk_domain_tree:
+            domain = dns.name.from_text(name_to_resolve)
+
+            while domain != dns.name.root:
+                try:
+                    lookup = dns.resolver.resolve(domain, dns_rdata_type)
+                    break
+                except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+                    domain = domain.parent()
+        else:
+            lookup = dns.resolver.resolve(name_to_resolve, dns_rdata_type)
+        return lookup
 
     def perform_acme_http_01_validation(self, request) -> DcvCheckResponse:
         domain_or_ip_target = request.domain_or_ip_target
@@ -84,21 +113,6 @@ class MpicDcvChecker:
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
             dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=str(e))]
-        return dcv_check_response
-
-    def perform_acme_dns_01_validation(self, request) -> DcvCheckResponse:
-        domain_or_ip_target = request.domain_or_ip_target
-        dns_record_type = dns.rdatatype.TXT
-        name_to_resolve = f"_acme-challenge.{domain_or_ip_target}"
-        expected_dns_record_content = request.dcv_check_parameters.validation_details.key_authorization
-        dcv_check_response = self.create_empty_check_response(DcvValidationMethod.DNS_CHANGE)
-
-        try:
-            lookup = dns.resolver.resolve(name_to_resolve, dns_record_type)
-            MpicDcvChecker.evaluate_dns_lookup_response(dcv_check_response, lookup, dns.rdatatype.TXT, expected_dns_record_content)
-        except dns.exception.DNSException as e:
-            dcv_check_response.timestamp_ns = time.time_ns()
-            dcv_check_response.errors = [MpicValidationError(error_type=e.__class__.__name__, error_message=e.msg)]
         return dcv_check_response
 
     def create_empty_check_response(self, validation_method: DcvValidationMethod) -> DcvCheckResponse:
@@ -137,13 +151,26 @@ class MpicDcvChecker:
 
     @staticmethod
     def evaluate_dns_lookup_response(dcv_check_response: DcvCheckResponse, lookup_response: dns.resolver.Answer,
-                                     dns_record_type: RdataType, expected_dns_record_content: str, exact_match: bool = True):
+                                     validation_method: DcvValidationMethod, dns_record_type: DnsRecordType,
+                                     expected_dns_record_content: str, exact_match: bool = True):
         response_code = lookup_response.response.rcode
         records_as_strings = []
+        dns_rdata_type = dns.rdatatype.from_text(dns_record_type)
         for response_answer in lookup_response.response.answer:
-            if response_answer.rdtype == dns_record_type:
+            if response_answer.rdtype == dns_rdata_type:
                 for record_data in response_answer:
-                    record_data_as_string = record_data.to_text()
+                    if validation_method == DcvValidationMethod.CONTACT_EMAIL and dns_record_type == DnsRecordType.CAA:
+                        if record_data.tag.decode('utf-8').lower() == MpicDcvChecker.CONTACT_EMAIL_TAG:
+                            record_data_as_string = record_data.value.decode('utf-8')
+                        else:
+                            continue
+                    elif validation_method == DcvValidationMethod.CONTACT_PHONE and dns_record_type == DnsRecordType.CAA:
+                        if record_data.tag.decode('utf-8').lower() == MpicDcvChecker.CONTACT_PHONE_TAG:
+                            record_data_as_string = record_data.value.decode('utf-8')
+                        else:
+                            continue
+                    else:
+                        record_data_as_string = record_data.to_text()
                     # only need to remove enclosing quotes if they're there, e.g., for a TXT record
                     if record_data_as_string[0] == '"' and record_data_as_string[-1] == '"':
                         record_data_as_string = record_data_as_string[1:-1]
@@ -157,3 +184,4 @@ class MpicDcvChecker:
         dcv_check_response.details.records_seen = records_as_strings
         dcv_check_response.details.response_code = response_code
         dcv_check_response.details.ad_flag = lookup_response.response.flags & dns.flags.AD == dns.flags.AD  # single ampersand
+        dcv_check_response.details.found_at = lookup_response.qname.to_text(omit_final_dot=True)

--- a/tests/unit/open_mpic_core/test_check_response_details.py
+++ b/tests/unit/open_mpic_core/test_check_response_details.py
@@ -1,0 +1,29 @@
+import pytest
+
+from open_mpic_core.common_domain.check_response_details import DcvDnsCheckResponseDetails, DcvHttpCheckResponseDetails
+
+
+class TestMpicCaaChecker:
+    @pytest.mark.parametrize('details_as_json, expected_class', [
+        ('{"validation_method": "dns-change", "records_seen": ["foo"], "response_code": 5, "ad_flag": true, "found_at": "example.com"}',
+         DcvDnsCheckResponseDetails),
+        ('{"validation_method": "acme-dns-01", "records_seen": ["foo"], "response_code": 5, "ad_flag": true, "found_at": "example.com"}',
+         DcvDnsCheckResponseDetails),
+        ('{"validation_method": "contact-email", "records_seen": ["foo"], "response_code": 5, "ad_flag": true, "found_at": "example.com"}',
+         DcvDnsCheckResponseDetails),
+        ('{"validation_method": "contact-phone", "records_seen": ["foo"], "response_code": 5, "ad_flag": true, "found_at": "example.com"}',
+         DcvDnsCheckResponseDetails),
+        ('{"validation_method": "ip-lookup", "records_seen": ["foo"], "response_code": 5, "ad_flag": true, "found_at": "example.com"}',
+         DcvDnsCheckResponseDetails),
+        ('{"validation_method": "website-change-v2", "response_history": [], "response_url": "example.com", "response_status_code": 200, "response_page": "foo"}',
+         DcvHttpCheckResponseDetails),
+        ('{"validation_method": "acme-http-01", "response_history": [], "response_url": "example.com", "response_status_code": 200, "response_page": "foo"}',
+         DcvHttpCheckResponseDetails),
+    ])
+    def check_response_details__should_automatically_deserialize_into_correct_object_based_on_discriminator(self, details_as_json, expected_class):
+        details_as_object = expected_class.model_validate_json(details_as_json)
+        assert isinstance(details_as_object, expected_class)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -209,6 +209,16 @@ class TestMpicDcvChecker:
         dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
         assert dcv_response.check_passed is True
 
+    def dns_change_validation__should_allow_finding_expected_challenge_as_substring(self, set_env_variables, mocker):
+        dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_CHANGE)
+        dcv_request.dcv_check_parameters.validation_details.challenge_value = 'extraStuffchallenge-valueMoreStuff'
+        self.mock_dns_resolve_call(dcv_request, mocker)
+        dcv_request.dcv_check_parameters.validation_details.challenge_value = 'challenge-value'
+        dcv_request.dcv_check_parameters.validation_details.require_exact_match = False
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        assert dcv_response.check_passed is True
+
     @pytest.mark.parametrize('dns_name_prefix', ['_dnsauth', '', None])
     def dns_change_validation__should_use_dns_name_prefix_if_provided(self, set_env_variables, dns_name_prefix, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -378,8 +378,8 @@ class TestMpicDcvChecker:
         txt_record_1 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, record_data)
         txt_record_2 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'whatever2'})
         txt_record_3 = MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'whatever3'})
-        test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer_with_multiple_txt_records(
-            dcv_request.domain_or_ip_target, record_name_prefix,
+        test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer_with_multiple_records(
+            dcv_request.domain_or_ip_target, record_name_prefix, DnsRecordType.TXT,
             *[txt_record_1, txt_record_2, txt_record_3], mocker=mocker
         )
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -20,19 +20,6 @@ from unit.test_util.valid_check_creator import ValidCheckCreator
 # noinspection PyMethodMayBeStatic
 class TestMpicDcvChecker:
     @staticmethod
-    @pytest.fixture(scope='class')
-    def set_env_variables():
-        envvars = {
-            'default_caa_domains': 'ca1.com|ca2.net|ca3.org',
-            'AWS_REGION': 'us-east-4',
-            'rir_region': 'arin',
-        }
-        with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
-            for k, v in envvars.items():
-                class_scoped_monkeypatch.setenv(k, v)
-            yield class_scoped_monkeypatch  # restore the environment afterward
-
-    @staticmethod
     def create_configured_dcv_checker(rir: str = 'arin', perspective_code: str = 'us-east-4'):
         return MpicDcvChecker(RemotePerspective(rir=rir, code=perspective_code))
 
@@ -47,33 +34,45 @@ class TestMpicDcvChecker:
                 setattr(response, k, v)
         return response
 
+    # TODO should we implement FOLLOWING of CNAME records for other challenges such as TXT?
     # integration test of a sort -- only mocking dns methods rather than remaining class methods
     @pytest.mark.parametrize('validation_method, record_type', [(DcvValidationMethod.WEBSITE_CHANGE_V2, None),
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.TXT),
                                                                 (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CNAME),
+                                                                (DcvValidationMethod.DNS_CHANGE, DnsRecordType.CAA),
+                                                                (DcvValidationMethod.CONTACT_EMAIL, DnsRecordType.TXT),
+                                                                (DcvValidationMethod.CONTACT_EMAIL, DnsRecordType.CAA),
+                                                                (DcvValidationMethod.CONTACT_PHONE, DnsRecordType.TXT),
+                                                                (DcvValidationMethod.CONTACT_PHONE, DnsRecordType.CAA),
+                                                                (DcvValidationMethod.IP_LOOKUP, DnsRecordType.A),
+                                                                (DcvValidationMethod.IP_LOOKUP, DnsRecordType.AAAA),
                                                                 (DcvValidationMethod.ACME_HTTP_01, None),
                                                                 (DcvValidationMethod.ACME_DNS_01, None)])
-    def check_dcv__should_perform_appropriate_check_and_allow_issuance_given_target_record_found(self, set_env_variables, validation_method, record_type, mocker):
+    def check_dcv__should_perform_appropriate_check_and_allow_issuance_given_target_record_found(self, validation_method, record_type, mocker):
+        dcv_request = None
         match validation_method:
-            case DcvValidationMethod.WEBSITE_CHANGE_V2:
+            case DcvValidationMethod.WEBSITE_CHANGE_V2 | DcvValidationMethod.ACME_HTTP_01:
                 dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
-                self.mock_http_call_response(dcv_request, mocker)
             case DcvValidationMethod.DNS_CHANGE:
                 dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
-                self.mock_dns_resolve_call(dcv_request, mocker)
-            case DcvValidationMethod.ACME_HTTP_01:
+            case DcvValidationMethod.CONTACT_EMAIL | DcvValidationMethod.CONTACT_PHONE:
+                dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method, record_type)
+            case DcvValidationMethod.IP_LOOKUP:
+                dcv_request = ValidCheckCreator.create_valid_ip_lookup_check_request(record_type)
+            case DcvValidationMethod.ACME_DNS_01:
                 dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
-                self.mock_http_call_response(dcv_request, mocker)
-            case _:
-                dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
-                self.mock_dns_resolve_call(dcv_request, mocker)
+        if (validation_method == DcvValidationMethod.WEBSITE_CHANGE_V2 or
+                validation_method == DcvValidationMethod.ACME_HTTP_01):
+            self.mock_http_call_response(dcv_request, mocker)
+        else:
+            self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_response = dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison
         assert dcv_response.check_passed is True
 
     @pytest.mark.skip('this is just for local debugging...')  # FIXME delete this before long
-    def delete_me__this_is_used_for_local_debugging_for_now(self, set_env_variables):
+    def delete_me__this_is_used_for_local_debugging_for_now(self):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.domain_or_ip_target = 'sectigo.com'  # 404: 'https://blog.fluidui.com/moomoomoo'
         dcv_request.dcv_check_parameters.validation_details.url_scheme = 'https'
@@ -82,7 +81,7 @@ class TestMpicDcvChecker:
         assert dcv_response.check_passed is True
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_check_success_given_token_file_found_with_expected_content(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_check_success_given_token_file_found_with_expected_content(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_http_call_response(dcv_request, mocker)
@@ -90,7 +89,7 @@ class TestMpicDcvChecker:
         assert dcv_response.check_passed is True
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_timestamp_and_response_url_and_status_code(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_timestamp_and_response_url_and_status_code(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_http_call_response(dcv_request, mocker)
@@ -108,7 +107,7 @@ class TestMpicDcvChecker:
         assert dcv_response.details.response_status_code == 200
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_check_failure_given_token_file_not_found(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_check_failure_given_token_file_not_found(self, validation_method, mocker):
         fail_response = TestMpicDcvChecker.create_mock_response(404, 'Not Found', {'reason': 'Not Found'})
         mocker.patch('requests.get', return_value=fail_response)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
@@ -117,7 +116,7 @@ class TestMpicDcvChecker:
         assert dcv_response.check_passed is False
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_error_details_given_token_file_not_found(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_error_details_given_token_file_not_found(self, validation_method, mocker):
         fail_response = TestMpicDcvChecker.create_mock_response(404, 'Not Found', {'reason': 'Not Found'})
         mocker.patch('requests.get', return_value=fail_response)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
@@ -129,7 +128,7 @@ class TestMpicDcvChecker:
         assert dcv_response.errors == errors
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_check_failure_and_error_details_given_exception_raised(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_check_failure_and_error_details_given_exception_raised(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         mocker.patch('requests.get', side_effect=lambda *args, **kwargs: self.raise_(RequestException('Test Exception')))
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
@@ -139,7 +138,7 @@ class TestMpicDcvChecker:
         assert dcv_response.errors == errors
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_return_check_failure_given_non_matching_response_content(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_return_check_failure_given_non_matching_response_content(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_http_call_response(dcv_request, mocker)
@@ -154,7 +153,7 @@ class TestMpicDcvChecker:
         (DcvValidationMethod.WEBSITE_CHANGE_V2, '.well-known/pki-validation'),
         (DcvValidationMethod.ACME_HTTP_01, '.well-known/acme-challenge')
     ])
-    def http_based_dcv_checks__should_auto_insert_well_known_path_segment(self, set_env_variables, validation_method, expected_segment, mocker):
+    def http_based_dcv_checks__should_auto_insert_well_known_path_segment(self, validation_method, expected_segment, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         match validation_method:
@@ -170,7 +169,7 @@ class TestMpicDcvChecker:
         assert dcv_response.details.response_url == expected_url
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_follow_redirects_and_track_redirect_history_in_details(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_follow_redirects_and_track_redirect_history_in_details(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_http_call_response_with_redirects(dcv_request, mocker)
@@ -183,7 +182,7 @@ class TestMpicDcvChecker:
         assert redirects[1].status_code == 302
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.WEBSITE_CHANGE_V2, DcvValidationMethod.ACME_HTTP_01])
-    def http_based_dcv_checks__should_include_up_to_first_100_bytes_of_returned_content_in_details(self, set_env_variables, validation_method, mocker):
+    def http_based_dcv_checks__should_include_up_to_first_100_bytes_of_returned_content_in_details(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_website_change_validation_large_payload(mocker)
@@ -192,7 +191,7 @@ class TestMpicDcvChecker:
         assert dcv_response.details.response_page == hundred_a_chars
 
     @pytest.mark.parametrize('url_scheme', ['http', 'https'])
-    def website_change_v2_validation__should_use_specified_url_scheme(self, set_env_variables, url_scheme, mocker):
+    def website_change_v2_validation__should_use_specified_url_scheme(self, url_scheme, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.validation_details.url_scheme = url_scheme
         self.mock_http_call_response(dcv_request, mocker)
@@ -202,57 +201,104 @@ class TestMpicDcvChecker:
         assert dcv_response.details.response_url.startswith(f"{url_scheme}://")
 
     @pytest.mark.parametrize('record_type', [DnsRecordType.TXT, DnsRecordType.CNAME])
-    def dns_change_validation__should_return_check_success_given_expected_dns_record_found(self, set_env_variables, record_type, mocker):
+    def dns_validation__should_return_check_success_given_expected_dns_record_found(self, record_type, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
         self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
-        dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
 
-    def dns_change_validation__should_allow_finding_expected_challenge_as_substring(self, set_env_variables, mocker):
+    def dns_validation__should_allow_finding_expected_challenge_as_substring(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_CHANGE)
         dcv_request.dcv_check_parameters.validation_details.challenge_value = 'extraStuffchallenge-valueMoreStuff'
         self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_request.dcv_check_parameters.validation_details.challenge_value = 'challenge-value'
         dcv_request.dcv_check_parameters.validation_details.require_exact_match = False
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
-        dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
 
     @pytest.mark.parametrize('dns_name_prefix', ['_dnsauth', '', None])
-    def dns_change_validation__should_use_dns_name_prefix_if_provided(self, set_env_variables, dns_name_prefix, mocker):
+    def dns_validation__should_use_dns_name_prefix_if_provided(self, dns_name_prefix, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()
         dcv_request.dcv_check_parameters.validation_details.dns_name_prefix = dns_name_prefix
-        self.mock_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
-        dcv_response = dcv_checker.perform_dns_change_validation(dcv_request)
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
+        if dns_name_prefix is not None and len(dns_name_prefix) > 0:
+            mock_dns_resolver_resolve.assert_called_once_with(f"{dns_name_prefix}.{dcv_request.domain_or_ip_target}", dns.rdatatype.TXT)
+        else:
+            mock_dns_resolver_resolve.assert_called_once_with(dcv_request.domain_or_ip_target, dns.rdatatype.TXT)
 
-    def acme_dns_validation__should_auto_insert_acme_challenge_prefix(self, set_env_variables, mocker):
+    def acme_dns_validation__should_auto_insert_acme_challenge_prefix(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_acme_dns_01_check_request()
-        self.mock_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
-        dcv_response = dcv_checker.perform_acme_dns_01_validation(dcv_request)
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
-        dcv_response.details.records_seen = ['_acme-challenge.example.com']
+        mock_dns_resolver_resolve.assert_called_once_with(f"_acme-challenge.{dcv_request.domain_or_ip_target}", dns.rdatatype.TXT)
 
-    def acme_dns_validation__should_return_check_success_given_expected_dns_record_found(self, set_env_variables, mocker):
-        dcv_request = ValidCheckCreator.create_valid_acme_dns_01_check_request()
+    def contact_email_txt_lookup__should_auto_insert_validation_prefix(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_contact_check_request(DcvValidationMethod.CONTACT_EMAIL, DnsRecordType.TXT)
+        mock_dns_resolver_resolve = self.mock_dns_resolve_call(dcv_request, mocker)
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
+        assert dcv_response.check_passed is True
+        mock_dns_resolver_resolve.assert_called_once_with(f"_validation-contactemail.{dcv_request.domain_or_ip_target}", dns.rdatatype.TXT)
+
+    def contact_phone_txt_lookup__should_auto_insert_validation_prefix(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_contact_check_request(DcvValidationMethod.CONTACT_PHONE, DnsRecordType.TXT)
+        mock_dns_resolver_resolve = self.mock_dns_resolve_call(dcv_request, mocker)
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
+        assert dcv_response.check_passed is True
+        mock_dns_resolver_resolve.assert_called_once_with(f"_validation-contactphone.{dcv_request.domain_or_ip_target}", dns.rdatatype.TXT)
+
+    @pytest.mark.parametrize('validation_method, tag, expected_result', [
+        (DcvValidationMethod.CONTACT_EMAIL, 'issue', False),
+        (DcvValidationMethod.CONTACT_EMAIL, 'contactemail', True),
+        (DcvValidationMethod.CONTACT_PHONE, 'issue', False),
+        (DcvValidationMethod.CONTACT_PHONE, 'contactphone', True)
+    ])
+    def contact_info_caa_lookup__should_fail_if_required_tag_not_found(self, validation_method, tag, expected_result, mocker):
+        dcv_request = ValidCheckCreator.create_valid_contact_check_request(validation_method, DnsRecordType.CAA)
+        dcv_details = dcv_request.dcv_check_parameters.validation_details
+        record_data = {'flags': 0, 'tag': tag, 'value': dcv_details.challenge_value}  # should be contactemail, contactphone
+        test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer(
+            dcv_request.domain_or_ip_target, dcv_details.dns_name_prefix, DnsRecordType.CAA, record_data, mocker
+        )
+        mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)
+        dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
+        assert dcv_response.check_passed is expected_result
+
+    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.CONTACT_EMAIL, DcvValidationMethod.CONTACT_PHONE])
+    def contact_info_caa_lookup__should_climb_domain_tree_to_find_records_and_include_domain_with_found_record_in_details(self, validation_method, mocker):
+        dcv_request = ValidCheckCreator.create_valid_contact_check_request(validation_method, DnsRecordType.CAA)
         self.mock_dns_resolve_call(dcv_request, mocker)
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
-        dcv_response = dcv_checker.perform_acme_dns_01_validation(dcv_request)
+        current_target = dcv_request.domain_or_ip_target
+        dcv_request.domain_or_ip_target = f"sub2.sub1.{current_target}"
+        dcv_response = dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
+        assert dcv_response.details.found_at == current_target
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.ACME_DNS_01])
-    def dns_based_dcv_checks__should_return_check_failure_given_non_matching_dns_record(self, set_env_variables, validation_method, mocker):
+    def dns_based_dcv_checks__should_return_check_failure_given_non_matching_dns_record(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
-        self.mock_dns_resolve_call_with_non_matching_record(dcv_request, mocker)
+        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
+        test_dns_query_answer.response.answer[0].items.clear()
+        test_dns_query_answer.response.answer[0].add(
+            MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'not-the-expected-value'})
+        )
+        mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)
         dcv_response = dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.ACME_DNS_01])
-    def dns_based_dcv_checks__should_return_timestamp_and_list_of_records_seen(self, set_env_variables, validation_method, mocker):
+    def dns_based_dcv_checks__should_return_timestamp_and_list_of_records_seen(self, validation_method, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_dns_resolve_call_getting_multiple_txt_records(dcv_request, mocker)
@@ -270,7 +316,7 @@ class TestMpicDcvChecker:
         (DcvValidationMethod.ACME_DNS_01, Rcode.NXDOMAIN),
         (DcvValidationMethod.DNS_CHANGE, Rcode.REFUSED)
     ])
-    def dns_based_dcv_checks__should_return_response_code(self, set_env_variables, validation_method, response_code, mocker):
+    def dns_based_dcv_checks__should_return_response_code(self, validation_method, response_code, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_dns_resolve_call_with_specific_response_code(dcv_request, response_code, mocker)
@@ -283,7 +329,7 @@ class TestMpicDcvChecker:
         (DcvValidationMethod.ACME_DNS_01, dns.flags.AD, True),
         (DcvValidationMethod.ACME_DNS_01, dns.flags.CD, False)
     ])
-    def dns_based_dcv_checks__should_return_whether_response_has_ad_flag(self, validation_method, flag, flag_set, set_env_variables, mocker):
+    def dns_based_dcv_checks__should_return_whether_response_has_ad_flag(self, validation_method, flag, flag_set, mocker):
         dcv_checker = TestMpicDcvChecker.create_configured_dcv_checker()
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         self.mock_dns_resolve_call_with_specific_flag(dcv_request, flag, mocker)
@@ -291,7 +337,7 @@ class TestMpicDcvChecker:
         assert dcv_response.details.ad_flag is flag_set
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.ACME_DNS_01])
-    def dns_based_dcv_checks__should_return_check_failure_with_errors_given_exception_raised(self, set_env_variables, validation_method, mocker):
+    def dns_based_dcv_checks__should_return_check_failure_with_errors_given_exception_raised(self, validation_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(validation_method)
         no_answer_error = dns.resolver.NoAnswer()
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: self.raise_(no_answer_error))
@@ -343,28 +389,28 @@ class TestMpicDcvChecker:
             TestMpicDcvChecker.create_mock_response(200, expected_challenge, {'history': history})
         ))
 
-    def mock_dns_resolve_call(self, dcv_request: DcvCheckRequest, mocker):
+    def mock_dns_resolve_call(self, dcv_request: DcvCheckRequest, mocker) -> MagicMock:
+        dns_name_prefix = dcv_request.dcv_check_parameters.validation_details.dns_name_prefix
+        if dns_name_prefix is not None and len(dns_name_prefix) > 0:
+            expected_domain = f"{dns_name_prefix}.{dcv_request.domain_or_ip_target}"
+        else:
+            expected_domain = dcv_request.domain_or_ip_target
+
         match dcv_request.dcv_check_parameters.validation_details.validation_method:
-            case DcvValidationMethod.DNS_CHANGE:
-                dns_name_prefix = dcv_request.dcv_check_parameters.validation_details.dns_name_prefix
-                if dns_name_prefix is not None and len(dns_name_prefix) > 0:
-                    expected_domain = f"{dns_name_prefix}.{dcv_request.domain_or_ip_target}"
-                else:
-                    expected_domain = dcv_request.domain_or_ip_target
-            case _:
-                expected_domain = f"_acme-challenge.{dcv_request.domain_or_ip_target}"
+            case DcvValidationMethod.CONTACT_PHONE:
+                if dcv_request.dcv_check_parameters.validation_details.dns_record_type == DnsRecordType.TXT:
+                    expected_domain = f"_validation-contactphone.{dcv_request.domain_or_ip_target}"
+                else:  # CAA -- using dns names instead of strings
+                    expected_domain = dns.name.from_text(expected_domain)
+            case DcvValidationMethod.CONTACT_EMAIL:
+                if dcv_request.dcv_check_parameters.validation_details.dns_record_type == DnsRecordType.TXT:
+                    expected_domain = f"_validation-contactemail.{dcv_request.domain_or_ip_target}"
+                else:  # CAA -- using dns names instead of strings
+                    expected_domain = dns.name.from_text(expected_domain)
         test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
-        mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: (
+        return mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: (
             test_dns_query_answer if domain_name == expected_domain else self.raise_(dns.resolver.NoAnswer)
         ))
-
-    def mock_dns_resolve_call_with_non_matching_record(self, dcv_request: DcvCheckRequest, mocker):
-        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
-        test_dns_query_answer.response.answer[0].items.clear()
-        test_dns_query_answer.response.answer[0].add(
-            MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {'value': 'not-the-expected-value'})
-        )
-        mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: test_dns_query_answer)
 
     def mock_dns_resolve_call_with_specific_response_code(self, dcv_request: DcvCheckRequest, response_code, mocker):
         test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
@@ -396,15 +442,27 @@ class TestMpicDcvChecker:
 
     def create_basic_dns_response_for_mock(self, dcv_request: DcvCheckRequest, mocker) -> dns.resolver.Answer:
         dcv_details = dcv_request.dcv_check_parameters.validation_details
-        match dcv_request.dcv_check_parameters.validation_details.validation_method:
-            case DcvValidationMethod.DNS_CHANGE:
-                record_data = {'value': dcv_details.challenge_value}
-                record_prefix = dcv_details.dns_name_prefix
-                record_type = dcv_details.dns_record_type
+        match dcv_details.validation_method:
+            case DcvValidationMethod.DNS_CHANGE | DcvValidationMethod.IP_LOOKUP:
+                match dcv_details.dns_record_type:
+                    case DnsRecordType.CNAME | DnsRecordType.TXT | DnsRecordType.A | DnsRecordType.AAAA:
+                        record_data = {'value': dcv_details.challenge_value}
+                    case _:  # CAA
+                        record_data = {'flags': '', 'tag': 'issue', 'value': dcv_details.challenge_value}
+            case DcvValidationMethod.CONTACT_EMAIL:
+                if dcv_details.dns_record_type == DnsRecordType.CAA:
+                    record_data = {'flags': '', 'tag': 'contactemail', 'value': dcv_details.challenge_value}
+                else:
+                    record_data = {'value': dcv_details.challenge_value}
+            case DcvValidationMethod.CONTACT_PHONE:
+                if dcv_details.dns_record_type == DnsRecordType.CAA:
+                    record_data = {'flags': '', 'tag': 'contactphone', 'value': dcv_details.challenge_value}
+                else:
+                    record_data = {'value': dcv_details.challenge_value}
             case _:  # ACME_DNS_01
                 record_data = {'value': dcv_details.key_authorization}
-                record_prefix = '_acme-challenge'
-                record_type = DnsRecordType.TXT
+        record_type = dcv_details.dns_record_type
+        record_prefix = dcv_details.dns_name_prefix
         test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer(
             dcv_request.domain_or_ip_target, record_prefix, record_type, record_data, mocker
         )

--- a/tests/unit/open_mpic_core/test_mpic_dcv_request.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_request.py
@@ -117,6 +117,18 @@ class TestMpicDcvRequest:
         mpic_request = MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert mpic_request.dcv_check_parameters.validation_details.url_scheme == UrlScheme.HTTP
 
+    @pytest.mark.parametrize('validation_method, expected_prefix', [
+        (DcvValidationMethod.CONTACT_EMAIL, '_validation-contactemail'),
+        (DcvValidationMethod.CONTACT_PHONE, '_validation-contactphone')
+    ])  # imperfect test because Pydantic seems to spit out a ton of errors trying to deserialize the JSON correctly
+    def mpic_dcv_request__should_enforce_domain_prefix_for_contact_lookup_for_txt_records(self, validation_method, expected_prefix):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request(validation_method)
+        request.dcv_check_parameters.validation_details.dns_name_prefix = 'moo'
+        with pytest.raises(pydantic.ValidationError) as validation_error:
+            MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
+        print(validation_error.value.json(indent=4))
+        assert expected_prefix in str(validation_error.value)
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,5 +1,7 @@
 from open_mpic_core.common_domain.check_parameters import DcvCheckParameters, DcvWebsiteChangeValidationDetails, \
-    DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails, DcvAcmeDns01ValidationDetails
+    DcvDnsChangeValidationDetails, CaaCheckParameters, DcvAcmeHttp01ValidationDetails, DcvAcmeDns01ValidationDetails, \
+    DcvIpLookupValidationDetails, DcvContactEmailCaaValidationDetails, DcvContactEmailTxtValidationDetails, \
+    DcvContactPhoneCaaValidationDetails, DcvContactPhoneTxtValidationDetails
 from open_mpic_core.common_domain.check_request import DcvCheckRequest, CaaCheckRequest
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
@@ -9,14 +11,14 @@ from open_mpic_core.common_domain.enum.url_scheme import UrlScheme
 
 class ValidCheckCreator:
     @staticmethod
-    def create_valid_caa_check_request():
+    def create_valid_caa_check_request() -> CaaCheckRequest:
         return CaaCheckRequest(domain_or_ip_target='example.com',
                                caa_check_parameters=CaaCheckParameters(
                                    certificate_type=CertificateType.TLS_SERVER, caa_domains=['ca1.com']
                                ))
 
     @staticmethod
-    def create_valid_http_check_request():
+    def create_valid_http_check_request() -> DcvCheckRequest:
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
                                    validation_details=DcvWebsiteChangeValidationDetails(
@@ -27,17 +29,57 @@ class ValidCheckCreator:
                                ))
 
     @staticmethod
-    def create_valid_dns_check_request(record_type=DnsRecordType.TXT):
-        return DcvCheckRequest(domain_or_ip_target='example.com',
-                               dcv_check_parameters=DcvCheckParameters(
-                                   validation_details=DcvDnsChangeValidationDetails(
-                                       dns_name_prefix='_dnsauth',
-                                       dns_record_type=record_type,
-                                       challenge_value=f"{record_type}_challenge_111.ca1.com.")
-                               ))
+    def create_valid_dns_check_request(record_type=DnsRecordType.TXT) -> DcvCheckRequest:
+        check_request = DcvCheckRequest(
+                            domain_or_ip_target='example.com',
+                            dcv_check_parameters=DcvCheckParameters(
+                                validation_details=DcvDnsChangeValidationDetails(
+                                    dns_name_prefix='_dnsauth',
+                                    dns_record_type=record_type,
+                                    challenge_value=f"{record_type}_challenge_111.ca1.com."
+                                )
+                            ))
+        check_request.dcv_check_parameters.validation_details.require_exact_match = False
+        return check_request
 
     @staticmethod
-    def create_valid_acme_http_01_check_request():
+    def create_valid_contact_check_request(validation_method: DcvValidationMethod, record_type: DnsRecordType) -> DcvCheckRequest:
+        match validation_method:
+            case DcvValidationMethod.CONTACT_EMAIL:
+                if record_type == DnsRecordType.CAA:
+                    validation_details = DcvContactEmailCaaValidationDetails(
+                        challenge_value='validate.me@example.com', dns_name_prefix='')
+                else:  # DnsRecordType.TXT
+                    validation_details = DcvContactEmailTxtValidationDetails(challenge_value=f"validate.me@example.com")
+            case _:  # DcvValidationMethod.CONTACT_PHONE
+                if record_type == DnsRecordType.CAA:
+                    validation_details = DcvContactPhoneCaaValidationDetails(
+                        challenge_value='555-555-5555', dns_name_prefix='')
+                else:  # DnsRecordType.TXT
+                    validation_details = DcvContactPhoneTxtValidationDetails(challenge_value='555-555-5555')
+        check_request = DcvCheckRequest(domain_or_ip_target='example.com', dcv_check_parameters=DcvCheckParameters(
+                                validation_details=validation_details
+                            ))
+        check_request.dcv_check_parameters.validation_details.require_exact_match = True
+        return check_request
+
+    @staticmethod
+    def create_valid_ip_lookup_check_request(record_type=DnsRecordType.A) -> DcvCheckRequest:
+        check_request = DcvCheckRequest(
+                            domain_or_ip_target='example.com',
+                            dcv_check_parameters=DcvCheckParameters(
+                                validation_details=DcvIpLookupValidationDetails(
+                                    dns_name_prefix='_dnsauth',
+                                    dns_record_type=record_type,
+                                    challenge_value='CHANGE_ME'
+                                )
+                            ))
+        challenge_value = '192.0.2.1' if record_type == DnsRecordType.A else '2001:db8::1'  # A or AAAA
+        check_request.dcv_check_parameters.validation_details.challenge_value = challenge_value
+        return check_request
+
+    @staticmethod
+    def create_valid_acme_http_01_check_request() -> DcvCheckRequest:
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
                                    validation_details=DcvAcmeHttp01ValidationDetails(
@@ -66,3 +108,5 @@ class ValidCheckCreator:
                 return ValidCheckCreator.create_valid_acme_http_01_check_request()
             case DcvValidationMethod.ACME_DNS_01:
                 return ValidCheckCreator.create_valid_acme_dns_01_check_request()
+            case DcvValidationMethod.CONTACT_EMAIL | DcvValidationMethod.CONTACT_PHONE:
+                return ValidCheckCreator.create_valid_contact_check_request(validation_method, record_type)

--- a/tests/unit/test_util/valid_mpic_request_creator.py
+++ b/tests/unit/test_util/valid_mpic_request_creator.py
@@ -1,6 +1,7 @@
 from open_mpic_core.common_domain.check_parameters import CaaCheckParameters, DcvCheckParameters, \
     DcvDnsChangeValidationDetails, DcvWebsiteChangeValidationDetails, DcvAcmeDns01ValidationDetails, \
-    DcvAcmeHttp01ValidationDetails
+    DcvAcmeHttp01ValidationDetails, DcvContactPhoneCaaValidationDetails, DcvContactPhoneTxtValidationDetails, \
+    DcvContactEmailTxtValidationDetails, DcvContactEmailCaaValidationDetails
 from open_mpic_core.common_domain.enum.certificate_type import CertificateType
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.enum.dns_record_type import DnsRecordType
@@ -40,11 +41,11 @@ class ValidMpicRequestCreator:
                 return ValidMpicRequestCreator.create_valid_dcv_mpic_request(validation_method)
 
     @classmethod
-    def create_validation_details(cls, validation_method=DcvValidationMethod.DNS_CHANGE):
+    def create_validation_details(cls, validation_method=DcvValidationMethod.DNS_CHANGE, dns_record_type=DnsRecordType.TXT):
         validation_details = {}
         match validation_method:
             case DcvValidationMethod.DNS_CHANGE:
-                validation_details = DcvDnsChangeValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
+                validation_details = DcvDnsChangeValidationDetails(dns_name_prefix='test', dns_record_type=dns_record_type, challenge_value='test')
             case DcvValidationMethod.WEBSITE_CHANGE_V2:
                 validation_details = DcvWebsiteChangeValidationDetails(
                     http_token_path='examplepath', challenge_value='test', url_scheme=UrlScheme.HTTP)  # noqa E501 (http)
@@ -52,4 +53,14 @@ class ValidMpicRequestCreator:
                 validation_details = DcvAcmeHttp01ValidationDetails(token='test', key_authorization='test')
             case DcvValidationMethod.ACME_DNS_01:
                 validation_details = DcvAcmeDns01ValidationDetails(key_authorization='test')
+            case DcvValidationMethod.CONTACT_PHONE:
+                if dns_record_type == DnsRecordType.CAA:
+                    validation_details = DcvContactPhoneCaaValidationDetails(dns_name_prefix='test', challenge_value='test')
+                else:
+                    validation_details = DcvContactPhoneTxtValidationDetails(challenge_value='test')
+            case DcvValidationMethod.CONTACT_EMAIL:
+                if dns_record_type == DnsRecordType.CAA:
+                    validation_details = DcvContactEmailCaaValidationDetails(dns_name_prefix='test', challenge_value='test')
+                else:
+                    validation_details = DcvContactEmailTxtValidationDetails(challenge_value='test')
         return validation_details


### PR DESCRIPTION
Added support for Contact based lookups, IP lookup, CAA based DCV.

Refactored tests and validation details / response details code a fair bit.

This creates further (minor) divergence from the OpenAPI spec, unfortunately.
I am going to make changes to that to reflect this and issue a PR there as well.

There's a lot of changes here, some may look awkward because I was making a trade-off between lots of code duplication and cyclomatic complexity within methods. I opted to have less duplication and to cover the logic forks ("if contact-email and CAA, then...") with tests. 