### PR TITLE
Fix HTTP-based DCV checks

### DIFF
--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -21,7 +21,7 @@ class DcvWebsiteChangeResponseDetails(BaseModel):
     response_history: list[RedirectResponse] | None = None  # list of redirects followed to final page
     response_url: str | None = None
     response_status_code: int | None = None
-    response_page: str | None = None  # first 100 bytes of page returned at final url (not base64 encoded)
+    response_page: str | None = None  # Base64 encoded first 100 bytes of page returned at final url
     # resolved_ip -- ip address used to communicate with domain_or_ip_target
 
 

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -10,6 +10,7 @@ from open_mpic_core.common_domain.check_response_details import RedirectResponse
 from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.common_domain.validation_error import MpicValidationError
+import base64
 
 
 # noinspection PyUnusedLocal
@@ -79,7 +80,7 @@ class MpicDcvChecker:
 
         try:
             urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
-            response = requests.get(url=token_url, verify=False)  # don't verify SSL so can follow redirects to HTTPS (correct?)
+            response = requests.get(url=token_url, stream=True, verify=False)  # don't verify SSL so can follow redirects to HTTPS (correct?)
             MpicDcvChecker.evaluate_http_lookup_response(dcv_check_response, response, token_url, expected_response_content)
         except requests.exceptions.RequestException as e:
             dcv_check_response.timestamp_ns = time.time_ns()
@@ -114,6 +115,7 @@ class MpicDcvChecker:
 
     @staticmethod
     def evaluate_http_lookup_response(dcv_check_response: DcvCheckResponse, lookup_response: requests.Response, target_url: str, challenge_value: str):
+        # TODO introduce a test to ensure that only the first 100 bytes of a potentially gigantic response are ever read. Important to prevent an attacker, for example, to force the CA to incur in excessive egress o large Lambda execution times cost.
         content = lookup_response.raw.read(100)
 
         response_history = None
@@ -126,13 +128,15 @@ class MpicDcvChecker:
         dcv_check_response.timestamp_ns = time.time_ns()
 
         if lookup_response.status_code == requests.codes.OK:
+            # Setting the internal Response._content to leverage decoding capabilities of Response.text without reading the entire response.
+            lookup_response._content = content
             result = lookup_response.text.strip()
             expected_response_content = challenge_value
             dcv_check_response.check_passed = (result == expected_response_content)
             dcv_check_response.details.response_status_code = lookup_response.status_code
             dcv_check_response.details.response_url = target_url
             dcv_check_response.details.response_history = response_history
-            dcv_check_response.details.response_page = content
+            dcv_check_response.details.response_page = base64.b64encode(content).decode()
         else:
             dcv_check_response.errors = [
                 MpicValidationError(error_type=str(lookup_response.status_code), error_message=lookup_response.reason)]


### PR DESCRIPTION
This fixes a bug due to a missing `stream` argument in the call to `requests.get` for acme-http-01 validation and a bug reading the HTTP response as text.

On the other hand, this PR suggests the usage of Base64 to encode the `DcvWebsiteChangeResponseDetails.response_page` to avoid an ugly and large encoding like the following:

```
"details": {
...
  "response_page": "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\u0010\u001a\u001b\u001b\u001d\u001e"
}
```

Additionally, JSON only supports encoding Unicode characters. Non-valid Unicode encodings in the response (e.g. `0x80` alone) would just produce an error like the following instead of returning any useful information to the user for analysis:


```
"perspectives": [
    {
      "perspective_code": "eu-west-2",
      "check_passed": false,
      "errors": [
        {
          "error_type": "mpic_error:coordinator:communication",
          "error_message": "Communication with the remote perspective failed."
        }
      ],
      "timestamp_ns": 1732481582175879858,
      "check_type": "dcv",
      "details": {
        "validation_method": "website-change-v2",
        "response_history": null,
        "response_url": null,
        "response_status_code": null,
        "response_page": null
      }
    },
```
