### PR TITLE
added configuration for packaging and deploying to package index (PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # open-mpic-core-python
+
 A Python implementation of the Open MPIC core library which can be adapted to various transports or deployment environments.
+
+## Overview
+
+The `open-mpic-core` library is a "common code" or "core" library for Open MPIC, written in Python. It is designed to be included in Python projects that wrap this code in something that can be invoked to leverage it. 
+
+For example:
+- The [aws-lambda-python](https://github.com/open-mpic/aws-lambda-python) GitHub project utilizes this library as part of an AWS Lambda-based MPIC implementation.
+- The [open-mpic-containers](https://github.com/open-mpic/open-mpic-containers) GitHub project uses this library to implement the key MPIC components (coordinator, CAA checker, DCV checker) as FastAPI-based Docker images that can be deployed as desired.
+
+## API Specification
+
+The `open-mpic-core` library utilizes object definitions which are based on the Open MPIC API Specification. This codebase is versioned to correspond to the Open MPIC API Specification version on which it is based. MPIC implementations based on this library should therefore be expected to conform to the corresponding Open MPIC API specification.
+
+## Installation
+
+To include the `open-mpic-core` library in your project, add it as a dependency in your `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+  "open-mpic-core"
+]
+```
+
+Alternatively, you can install it using pip:
+
+```sh
+pip install open-mpic-core
+```
+
+## Usage
+
+Here is an example of how to use the `open-mpic-core` library in your project:
+
+```python
+from open_mpic_core.mpic_caa_checker import MpicCaaChecker
+from open_mpic_core.common_domain import CaaCheckRequest, CaaCheckResponse
+
+# Create a CAA check request
+caa_request = CaaCheckRequest(
+    caa_check_parameters=...  # Fill in the required parameters
+)
+
+# Perform the CAA check
+checker = MpicCaaChecker()
+caa_response = checker.check_caa(caa_request)
+
+# Process the response
+if caa_response.check_passed:
+    print("CAA check passed")
+else:
+    print("CAA check failed")
+```
+
+## Contributing
+
+Contributions are welcome! Please see the [contributing guidelines](CONTRIBUTING.md) for more information.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Links
+
+- [Documentation](https://github.com/open-mpic/open-mpic-core-python)
+- [Issues](https://github.com/open-mpic/open-mpic-core-python/issues)
+- [Source](https://github.com/open-mpic/open-mpic-core-python)
+
+## Authors
+
+- Henry Birge-Lee
+- Grace Cimaszewski
+- Dmitry Sharkov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Source = "https://github.com/open-mpic/open-mpic-core-python"
 
 [tool.hatch]
 version.path = "src/open_mpic_core/__about__.py"
+build.name = "open-mpic-core"
 build.sources = ["src"]
 build.targets.wheel.packages = ["src/open_mpic_core"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "open-mpic-core-python"
+name = "open-mpic-core"
 dynamic = ["version"]
 description = 'Library of core (common) MPIC functionality for Open MPIC in Python.'
 readme = "README.md"
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: Implementation :: PyPy"
 ]
 dependencies = [
   "pyyaml==6.0.1",


### PR DESCRIPTION
Note that this codebase is for spec v2.2.0, which is still awaiting merge.
I have also pushed a branch named `ds-packaging-core` for the `aws-lambda-python` repo which uses the Test PyPI index (temporarily) to retrieve a packaged `open-mpic-core=2.2.0` instead of git submodules, which I tore out of that branch. If that one looks good, we can swap to using the real PyPI instead of Test PyPI and we can issue a PR in aws-lambda-python and also make the corresponding changes in the upcoming REST API Server repository. 