### PR TITLE
refactor (extraction) and unit tests

### DIFF
--- a/src/open_mpic_core/__init__.py
+++ b/src/open_mpic_core/__init__.py
@@ -20,6 +20,7 @@ from open_mpic_core.common_domain.check_parameters import (
     DcvContactPhoneCaaValidationParameters,
     DcvIpAddressValidationParameters,
     DcvReverseAddressLookupValidationParameters,
+    DcvAcmeTlsAlpn01ValidationParameters,
     DcvValidationParameters,
 )
 from open_mpic_core.common_domain.check_request import CheckRequest, CaaCheckRequest, DcvCheckRequest
@@ -31,6 +32,7 @@ from open_mpic_core.common_domain.check_response_details import (
     DcvCheckResponseDetailsBuilder,
     DcvDnsCheckResponseDetails,
     DcvHttpCheckResponseDetails,
+    DcvTlsAlpnCheckResponseDetails
 )
 from open_mpic_core.common_domain.check_response import CheckResponse, CaaCheckResponse, DcvCheckResponse
 
@@ -57,6 +59,9 @@ from open_mpic_core.mpic_coordinator.mpic_request_validator import MpicRequestVa
 from open_mpic_core.mpic_coordinator.mpic_response_builder import MpicResponseBuilder
 from open_mpic_core.mpic_coordinator.cohort_creator import CohortCreator
 from open_mpic_core.mpic_coordinator.mpic_coordinator import MpicCoordinator, MpicCoordinatorConfiguration
+
+from open_mpic_core.mpic_dcv_checker.dcv_utils import DcvUtils
+from open_mpic_core.mpic_dcv_checker.dcv_tls_alpn_validator import DcvTlsAlpnValidator
 
 from open_mpic_core.mpic_caa_checker.mpic_caa_checker import MpicCaaChecker
 from open_mpic_core.mpic_dcv_checker.mpic_dcv_checker import MpicDcvChecker

--- a/src/open_mpic_core/common_domain/check_parameters.py
+++ b/src/open_mpic_core/common_domain/check_parameters.py
@@ -107,6 +107,7 @@ class DcvAcmeDns01ValidationParameters(DcvValidationParameters):
     dns_record_type: Literal[DnsRecordType.TXT] = DnsRecordType.TXT
     dns_name_prefix: Literal["_acme-challenge"] = "_acme-challenge"
 
+
 class DcvAcmeTlsAlpn01ValidationParameters(DcvValidationParameters):
     validation_method: Literal[DcvValidationMethod.ACME_TLS_ALPN_01] = DcvValidationMethod.ACME_TLS_ALPN_01
     key_authorization_hash: str

--- a/src/open_mpic_core/common_domain/check_response_details.py
+++ b/src/open_mpic_core/common_domain/check_response_details.py
@@ -40,10 +40,9 @@ class DcvDnsCheckResponseDetails(BaseModel):
     ad_flag: bool | None = None  # was AD flag set in DNS response
     found_at: str | None = None  # domain where DNS record was found
 
+
 class DcvTlsAlpnCheckResponseDetails(BaseModel):
-    validation_method: Literal[
-        DcvValidationMethod.ACME_TLS_ALPN_01,
-        ]
+    validation_method: Literal[DcvValidationMethod.ACME_TLS_ALPN_01]
     common_name: str | None = None  # domain where DNS record was found
 
 

--- a/src/open_mpic_core/common_domain/enum/regional_internet_registry.py
+++ b/src/open_mpic_core/common_domain/enum/regional_internet_registry.py
@@ -10,6 +10,11 @@ class RegionalInternetRegistry(StrEnum):
 
     @classmethod
     def _missing_(cls, value: str) -> str | None:
+        """
+        This method is called when a value is not found in the enum. It basically makes enum lookups case-insensitive.
+        :param value: the string value to look up.
+        :return: The RegionalInternetRegistry member if found, otherwise None.
+        """
         value = value.upper()
         for member in cls:
             if member.upper() == value:

--- a/src/open_mpic_core/common_domain/messages/ErrorMessages.py
+++ b/src/open_mpic_core/common_domain/messages/ErrorMessages.py
@@ -12,6 +12,11 @@ class ErrorMessages(Enum):
     INVALID_REDIRECT_ERROR = ('mpic_error:redirect:invalid', 'Invalid redirect. Redirect code: {0}, target: {1}')
     COHORT_CREATION_ERROR = ('mpic_error:coordinator:cohort', 'The coordinator could not construct a cohort of size {0}')
 
+    TLS_ALPN_ERROR_CERTIFICATE_EXTENSION_MISSING = ('mpic_error:dcv_checker:tls_alpn:certificate:extension_missing', 'The TLS ALPN certificate was missing an extension.')
+    TLS_ALPN_ERROR_CERTIFICATE_NO_SINGLE_SAN = ('mpic_error:dcv_checker:tls_alpn:certificate:no_single_san', 'The TLS ALPN certificate must have a single SAN entry.')
+    TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_DNSNAME = ('mpic_error:dcv_checker:tls_alpn:certificate:san_not_dnsname', 'The TLS ALPN certificate SAN was not a DNSName.')
+    TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_HOSTNAME = ('mpic_error:dcv_checker:tls_alpn:certificate:san_not_hostname', 'The TLS ALPN certificate SAN was not equal to the hostname being validated.')
+
     def __init__(self, key, message):
         self.key = key
         self.message = message

--- a/src/open_mpic_core/mpic_coordinator/domain/remote_perspective.py
+++ b/src/open_mpic_core/mpic_coordinator/domain/remote_perspective.py
@@ -6,8 +6,7 @@ from open_mpic_core.common_domain.enum.regional_internet_registry import Regiona
 
 class RemotePerspective(BaseModel):
     code: str  # example: "us-west-2"
-    # name seems to be an unused var and based on the spec the code seems to uniquely define a perspective.
-    name: str | None = None  # example: "US West (Oregon)"
+    name: str | None = None  # example: "US West (Oregon)" (optional)
     rir: RegionalInternetRegistry  # example: "RegionalInternetRegistry.ARIN"
     too_close_codes: list[str] | None = field(default_factory=list)  # example: ["us-west-1", "us-west-2"]
 

--- a/src/open_mpic_core/mpic_coordinator/mpic_request_validation_issue.py
+++ b/src/open_mpic_core/mpic_coordinator/mpic_request_validation_issue.py
@@ -1,4 +1,7 @@
+from open_mpic_core.mpic_coordinator.messages.mpic_request_validation_messages import MpicRequestValidationMessages
+
+
 class MpicRequestValidationIssue:
-    def __init__(self, validation_message, *message_args):
+    def __init__(self, validation_message: MpicRequestValidationMessages, *message_args):
         self.issue_type = validation_message.key
         self.message = validation_message.message.format(*message_args)

--- a/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
+++ b/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
@@ -1,0 +1,124 @@
+import asyncio
+import time
+import socket
+import ssl
+import traceback
+
+from aiohttp import ClientError
+from aiohttp.web import HTTPException
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
+
+from open_mpic_core import DcvCheckRequest, DcvCheckResponse, DcvValidationMethod, DcvUtils
+from open_mpic_core import MpicValidationError, ErrorMessages
+from open_mpic_core import get_logger
+
+logger = get_logger(__name__)
+
+
+class DcvTlsAlpnValidator:
+    # See id-pe-acmeIdentifier in https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml
+    ACME_TLS_ALPN_OID_DOTTED_STRING = "1.3.6.1.5.5.7.1.31"  # not found in cryptography.x509.oid list, so hardcoding
+    ACME_TLS_ALPN_PROTOCOL = "acme-tls/1"
+
+    def __init__(
+        self,
+        log_level: int = None,
+    ):
+        self.logger = logger.getChild(self.__class__.__name__)
+        if log_level is not None:
+            self.logger.setLevel(log_level)
+
+    async def perform_tls_alpn_validation(self, request: DcvCheckRequest) -> DcvCheckResponse:
+        self.logger.info("!!!!! entering alpn block")
+        validation_method = request.dcv_check_parameters.validation_method
+        assert validation_method == DcvValidationMethod.ACME_TLS_ALPN_01
+        key_authorization_hash = request.dcv_check_parameters.key_authorization_hash
+        self.logger.info("!!!!! before response builder")
+        dcv_check_response = DcvUtils.create_empty_check_response(validation_method)
+        hostname = request.domain_or_ip_target
+
+        try:
+            self.logger.info("!!!!! try alpn block")
+            self.logger.info(f"hostname: {hostname}")
+            context = ssl.create_default_context()
+            context.set_alpn_protocols([self.ACME_TLS_ALPN_PROTOCOL])
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+            with socket.create_connection((hostname, 443)) as generic_tls_connection:
+                self.logger.info("!!!!! first with (created 443 connection)")
+                dcv_check_response.check_completed = True  # If we made the socket, we can mark the check as completed.
+                with context.wrap_socket(generic_tls_connection, server_hostname=hostname) as tls_alpn_connection:
+                    self.logger.info("!!!!! second with (wrapped connection in tls alpn context)")
+                    binary_cert = tls_alpn_connection.getpeercert(binary_form=True)
+                    x509_cert = x509.load_der_x509_certificate(binary_cert)
+                    self.logger.info("x509_cert from binary form.")
+
+                    subject_alt_name_extension = None
+                    acme_tls_alpn_extension = None
+
+                    for extension in x509_cert.extensions:
+                        if extension.oid.dotted_string == self.ACME_TLS_ALPN_OID_DOTTED_STRING:
+                            acme_tls_alpn_extension = extension
+                        elif extension.oid.dotted_string == ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string:
+                            subject_alt_name_extension = extension
+                    self.logger.info("all indexes expanded.")
+                    # We need both of these extensions to proceed.
+                    if subject_alt_name_extension is None or acme_tls_alpn_extension is None:
+                        dcv_check_response.errors = [
+                            MpicValidationError.create(ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_EXTENSION_MISSING)
+                        ]
+                    else:
+                        self.logger.info("both extensions found")
+                        # We now know we have both extensions present. Begin checking each one.
+                        dcv_check_response.errors = self._validate_san_entry(subject_alt_name_extension, hostname)
+                        if len(dcv_check_response.errors) == 0:
+                            # Check the id-pe-acmeIdentifier extension.
+                            binary_challenge_seen = acme_tls_alpn_extension.value.value
+                            key_authorization_hash_binary = None
+                            try:
+                                key_authorization_hash_binary = bytes.fromhex(key_authorization_hash)
+                                self.logger.info(f"binary_challenge_seen: {binary_challenge_seen}")
+                                self.logger.info(f"key_authorization_hash_binary: {key_authorization_hash_binary}")
+                                # Add the first two ASN.1 encoding bytes to the expected hex string.
+                                key_authorization_hash_binary = b"\x04\x20" + key_authorization_hash_binary
+                            except ValueError:
+                                dcv_check_response.errors = [
+                                    MpicValidationError.create(
+                                        ErrorMessages.DCV_PARAMETER_ERROR, key_authorization_hash
+                                    )
+                                ]
+                            dcv_check_response.check_passed = binary_challenge_seen == key_authorization_hash_binary
+                            self.logger.info(f"key hash test passed? {dcv_check_response.check_passed}")
+                dcv_check_response.timestamp_ns = time.time_ns()
+        except asyncio.TimeoutError as e:
+            dcv_check_response.timestamp_ns = time.time_ns()
+            log_message = f"Timeout connecting to {hostname}: {str(e)}. Trace identifier: {request.trace_identifier}"
+            self.logger.warning(log_message)
+            message = f"Connection timed out while attempting to connect to {hostname}"
+            dcv_check_response.errors = [
+                MpicValidationError.create(ErrorMessages.DCV_LOOKUP_ERROR, e.__class__.__name__, message)
+            ]
+        except (ClientError, HTTPException, OSError) as e:
+            self.logger.error(traceback.format_exc())
+            dcv_check_response.timestamp_ns = time.time_ns()
+            dcv_check_response.errors = [
+                MpicValidationError.create(ErrorMessages.DCV_LOOKUP_ERROR, e.__class__.__name__, str(e))
+            ]
+
+        return dcv_check_response
+
+    def _validate_san_entry(self, certificate_extension: x509.Extension, hostname: str) -> list:
+        errors = []
+        # noinspection PyProtectedMember
+        san_names = certificate_extension.value._general_names
+        if len(san_names) != 1:
+            errors = [MpicValidationError.create(ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_NO_SINGLE_SAN)]
+        single_san_name = san_names[0]
+        if not isinstance(single_san_name, x509.general_name.DNSName):
+            errors = [MpicValidationError.create(ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_DNSNAME)]
+        elif single_san_name.value != hostname:
+            errors = [MpicValidationError.create(ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_HOSTNAME)]
+        self.logger.info("san value is hostname")
+        return errors

--- a/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
+++ b/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
@@ -89,7 +89,9 @@ class DcvTlsAlpnValidator:
                                         ErrorMessages.DCV_PARAMETER_ERROR, key_authorization_hash
                                     )
                                 ]
-                            dcv_check_response.check_passed = binary_challenge_seen == key_authorization_hash_binary
+                            if binary_challenge_seen == key_authorization_hash_binary:
+                                dcv_check_response.check_passed = True
+                                dcv_check_response.details.common_name = hostname
                             self.logger.info(f"key hash test passed? {dcv_check_response.check_passed}")
                 dcv_check_response.timestamp_ns = time.time_ns()
         except asyncio.TimeoutError as e:

--- a/src/open_mpic_core/mpic_dcv_checker/dcv_utils.py
+++ b/src/open_mpic_core/mpic_dcv_checker/dcv_utils.py
@@ -1,0 +1,12 @@
+from open_mpic_core import DcvValidationMethod, DcvCheckResponse, DcvCheckResponseDetailsBuilder
+
+class DcvUtils:
+    @staticmethod
+    def create_empty_check_response(validation_method: DcvValidationMethod) -> DcvCheckResponse:
+        return DcvCheckResponse(
+            check_completed=False,
+            check_passed=False,
+            timestamp_ns=None,
+            errors=None,
+            details=DcvCheckResponseDetailsBuilder.build_response_details(validation_method),
+        )

--- a/tests/unit/open_mpic_core/test_check_response_details.py
+++ b/tests/unit/open_mpic_core/test_check_response_details.py
@@ -1,6 +1,7 @@
 import pytest
 
 from open_mpic_core import DcvDnsCheckResponseDetails, DcvHttpCheckResponseDetails
+from open_mpic_core.common_domain.check_response_details import DcvTlsAlpnCheckResponseDetails
 
 
 class TestCheckResponseDetails:
@@ -24,6 +25,7 @@ class TestCheckResponseDetails:
          DcvHttpCheckResponseDetails),
         ('{"validation_method": "acme-http-01", "response_history": [], "response_url": "example.com", "response_status_code": 200, "response_page": "foo"}',
          DcvHttpCheckResponseDetails),
+        ('{"validation_method": "acme-tls-alpn-01", "common_name": "example.com"}', DcvTlsAlpnCheckResponseDetails),
     ])
     # fmt: on
     def check_response_details__should_automatically_deserialize_into_correct_object_based_on_discriminator(self, details_as_json, expected_class):

--- a/tests/unit/open_mpic_core/test_dcv_tls_alpn_validator.py
+++ b/tests/unit/open_mpic_core/test_dcv_tls_alpn_validator.py
@@ -52,6 +52,17 @@ class TestDcvTlsAlpnValidator:
         assert response.check_passed is True
         assert not response.errors
 
+    async def perform_tls_alpn_validation__should_include_common_name_in_succesful_response(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        mock_cert = self._create_mock_certificate(
+            dcv_request.domain_or_ip_target, dcv_request.dcv_check_parameters.key_authorization_hash
+        )
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is True
+        assert response.details.common_name == dcv_request.domain_or_ip_target
+
     async def perform_tls_alpn_validation__should_fail_if_required_extensions_are_missing(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
         mock_cert = self._create_mock_certificate_without_extensions()

--- a/tests/unit/open_mpic_core/test_dcv_tls_alpn_validator.py
+++ b/tests/unit/open_mpic_core/test_dcv_tls_alpn_validator.py
@@ -1,0 +1,198 @@
+import logging
+import pytest
+import ssl
+import socket
+from unittest.mock import MagicMock
+from io import StringIO
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
+
+from open_mpic_core import ErrorMessages, TRACE_LEVEL
+from open_mpic_core import DcvTlsAlpnValidator
+
+from unit.test_util.valid_check_creator import ValidCheckCreator
+
+
+# noinspection PyMethodMayBeStatic
+class TestDcvTlsAlpnValidator:
+    @pytest.fixture(autouse=True)
+    def setup_validator(self):
+        # noinspection PyAttributeOutsideInit
+        self.validator = DcvTlsAlpnValidator()
+        yield self.validator
+
+    @pytest.fixture(autouse=True)
+    def setup_logging(self):
+        # Clear existing handlers
+        root = logging.getLogger()
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+
+        # noinspection PyAttributeOutsideInit
+        self.log_output = StringIO()  # to be able to inspect what gets logged
+        handler = logging.StreamHandler(self.log_output)
+        handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+
+        # Configure fresh logging
+        logging.basicConfig(level=TRACE_LEVEL, handlers=[handler])
+        yield
+
+    def constructor__should_set_log_level_if_provided(self):
+        validator = DcvTlsAlpnValidator(log_level=logging.ERROR)
+        assert validator.logger.level == logging.ERROR
+
+    async def perform_tls_alpn_validation__should_pass_with_valid_certificate(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        mock_cert = self._create_mock_certificate(
+            dcv_request.domain_or_ip_target, dcv_request.dcv_check_parameters.key_authorization_hash
+        )
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is True
+        assert not response.errors
+
+    async def perform_tls_alpn_validation__should_fail_if_required_extensions_are_missing(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        mock_cert = self._create_mock_certificate_without_extensions()
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is False
+        assert len(response.errors) == 1
+        assert response.errors[0].error_message == ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_EXTENSION_MISSING.message
+
+    async def perform_tls_alpn_validation__should_fail_given_invalid_san_entry(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        key_authorization_hash = dcv_request.dcv_check_parameters.key_authorization_hash
+        hostname = dcv_request.domain_or_ip_target
+        mock_cert = self._create_mock_certificate_with_non_dns_san_entry(hostname, key_authorization_hash)
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is False
+        assert len(response.errors) > 0
+        assert response.errors[0].error_message == ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_DNSNAME.message
+
+    async def perform_tls_alpn_validation__should_fail_given_multiple_san_entries(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        key_authorization_hash = dcv_request.dcv_check_parameters.key_authorization_hash
+        hostname = dcv_request.domain_or_ip_target
+        mock_cert = self._create_mock_certificate_with_multiple_san_entries(hostname, key_authorization_hash)
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is False
+        assert len(response.errors) > 0
+        assert response.errors[0].error_message == ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_NO_SINGLE_SAN.message
+
+    async def perform_tls_alpn_validation__should_fail_given_nonmatching_san_entry(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        key_authorization_hash = dcv_request.dcv_check_parameters.key_authorization_hash
+        hostname = dcv_request.domain_or_ip_target
+        mock_cert = self._create_mock_certificate_with_nonmatching_san_entry(hostname, key_authorization_hash)
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is False
+        assert len(response.errors) > 0
+        assert response.errors[0].error_message == ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_HOSTNAME.message
+
+    async def perform_tls_alpn_validation__should_fail_given_invalid_key_authorization_hash(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        hostname = dcv_request.domain_or_ip_target
+        key_authorization_hash = dcv_request.dcv_check_parameters.key_authorization_hash
+        mock_cert = self._create_mock_certificate(hostname, key_authorization_hash)
+        # Modify the mock certificate to have a different key authorization hash
+        dcv_request.dcv_check_parameters.key_authorization_hash = 'invalid_hash_value'
+        self._mock_socket_and_ssl_context(mocker, mock_cert)
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is True
+        assert response.check_passed is False
+        expected_error = ErrorMessages.DCV_PARAMETER_ERROR.message.format("invalid_hash_value")
+        assert response.errors[0].error_message == expected_error
+
+    async def perform_tls_alpn_validation__should_handle_connection_errors(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        # Mock socket to raise an exception
+        mocker.patch('socket.create_connection', side_effect=socket.timeout("Connection timed out"))
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is False
+        assert response.check_passed is False
+        assert len(response.errors) == 1
+
+    async def perform_tls_alpn_validation__should_handle_ssl_errors(self, mocker):
+        dcv_request = ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
+        # Mock SSL context to raise an exception
+        mocker.patch('ssl.create_default_context', side_effect=ssl.SSLError("SSL error"))
+        response = await self.validator.perform_tls_alpn_validation(dcv_request)
+        assert response.check_completed is False
+        assert response.check_passed is False
+        assert len(response.errors) == 1
+
+    def _create_mock_certificate(self, hostname, key_authorization_hash):
+        # Create a mock certificate with the required extensions
+        mock_cert = MagicMock()
+
+        dns_name = x509.general_name.DNSName(hostname)
+        san_extension = MagicMock()
+        san_extension.oid.dotted_string = ExtensionOID.SUBJECT_ALTERNATIVE_NAME.dotted_string
+        san_extension.value._general_names = [dns_name]  # must have exactly one DNS name
+
+        key_auth_hash_binary = bytes.fromhex(key_authorization_hash)
+        acme_extension = MagicMock()
+        acme_extension.oid.dotted_string = self.validator.ACME_TLS_ALPN_OID_DOTTED_STRING
+        acme_extension.value.value = b"\x04\x20" + key_auth_hash_binary
+
+        mock_cert.extensions = [san_extension, acme_extension]
+
+        return mock_cert
+
+    def _create_mock_certificate_without_extensions(self):
+        mock_cert = MagicMock()
+        mock_cert.extensions = []
+        return mock_cert
+
+    def _create_mock_certificate_with_multiple_san_entries(self, hostname, key_authorization_hash):
+        mock_cert = self._create_mock_certificate(hostname, key_authorization_hash)
+        # Create multiple SAN entries
+        san_extension = mock_cert.extensions[0]
+        mock_dns_name1 = x509.general_name.DNSName(hostname)
+        mock_dns_name2 = x509.general_name.DNSName("another.example.com")
+        san_extension.value._general_names = [mock_dns_name1, mock_dns_name2]
+        return mock_cert
+
+    def _create_mock_certificate_with_non_dns_san_entry(self, hostname, key_authorization_hash):
+        mock_cert = self._create_mock_certificate(hostname, key_authorization_hash)
+        # Create bad SAN entry
+        san_extension = mock_cert.extensions[0]
+        invalid_san = "bad.san"
+        san_extension.value._general_names = [invalid_san]
+        return mock_cert
+
+    def _create_mock_certificate_with_nonmatching_san_entry(self, hostname, key_authorization_hash):
+        mock_cert = self._create_mock_certificate(hostname, key_authorization_hash)
+        # Create a SAN entry that does not match the hostname
+        san_extension = mock_cert.extensions[0]
+        invalid_san = x509.general_name.DNSName("invalid.example.com")
+        san_extension.value._general_names = [invalid_san]
+        return mock_cert
+
+    def _mock_socket_and_ssl_context(self, mocker, mock_cert):
+        # Mock socket.create_connection
+        mock_socket = MagicMock()
+        mocker.patch('socket.create_connection', return_value=mock_socket)
+
+        # Mock SSL context and wrapped socket
+        mock_ssl_socket = MagicMock()
+        mock_ssl_socket.getpeercert.return_value = b'mock_binary_cert'
+
+        # Mock SSL context's wrap_socket method
+        mock_context = MagicMock()
+        mock_context.wrap_socket.return_value.__enter__.return_value = mock_ssl_socket
+        mocker.patch('ssl.create_default_context', return_value=mock_context)
+
+        # Mock x509.load_der_x509_certificate to return our mock certificate
+        mocker.patch('cryptography.x509.load_der_x509_certificate', return_value=mock_cert)
+
+        return mock_socket

--- a/tests/unit/open_mpic_core/test_mpic_coordinator.py
+++ b/tests/unit/open_mpic_core/test_mpic_coordinator.py
@@ -79,7 +79,7 @@ class TestMpicCoordinator:
         target_perspectives = coordinator_config.target_perspectives
         excessive_count = len(target_perspectives) + 1
         mpic_coordinator = MpicCoordinator(self.create_passing_caa_check_response, coordinator_config)
-        with pytest.raises(ValueError):
+        with pytest.raises(CohortCreationException):
             mpic_coordinator.shuffle_and_group_perspectives(target_perspectives, excessive_count, "test_target")
 
     def shuffle_and_group_perspectives__should_return_list_of_cohorts_of_requested_size(self):
@@ -310,7 +310,6 @@ class TestMpicCoordinator:
             if mpic_coordinator_config.target_perspectives[index].code != 'us-west-1':
                 mpic_coordinator_config.target_perspectives[index].too_close_codes = ['us-west-1']
 
-        print(mpic_coordinator_config)
         mocked_call_remote_perspective_function = AsyncMock()
         mocked_call_remote_perspective_function.side_effect = TestMpicCoordinator.SideEffectForMockedPayloads(
             self.create_passing_caa_check_response
@@ -330,7 +329,6 @@ class TestMpicCoordinator:
         for index in range(len(mpic_coordinator_config.target_perspectives)):
             mpic_coordinator_config.target_perspectives[index].rir = RegionalInternetRegistry.RIPE_NCC
 
-        print(mpic_coordinator_config)
         mocked_call_remote_perspective_function = AsyncMock()
         mocked_call_remote_perspective_function.side_effect = TestMpicCoordinator.SideEffectForMockedPayloads(
             self.create_passing_caa_check_response
@@ -338,7 +336,6 @@ class TestMpicCoordinator:
         mpic_coordinator = MpicCoordinator(mocked_call_remote_perspective_function, mpic_coordinator_config)
         with pytest.raises(CohortCreationException):
             await mpic_coordinator.coordinate_mpic(mpic_request)
-
 
     async def coordinate_mpic__should_cycle_through_perspective_cohorts_if_attempts_exceeds_cohort_number(self):
         mpic_coordinator_config = self.create_mpic_coordinator_configuration()

--- a/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
+++ b/tests/unit/open_mpic_core/test_mpic_dcv_checker.py
@@ -17,15 +17,10 @@ from aiohttp.web import HTTPInternalServerError
 from multidict import CIMultiDictProxy, CIMultiDict
 from dns.rcode import Rcode
 
-from open_mpic_core import (
-    DcvCheckRequest,
-    DcvValidationMethod,
-    DnsRecordType,
-    MpicValidationError,
-    MpicDcvChecker,
-    ErrorMessages,
-    TRACE_LEVEL,
-)
+from open_mpic_core import MpicDcvChecker, DcvCheckRequest, DcvCheckResponse
+from open_mpic_core import DcvTlsAlpnValidator, DcvCheckResponseDetailsBuilder
+from open_mpic_core import DcvValidationMethod, DnsRecordType
+from open_mpic_core import MpicValidationError, ErrorMessages, TRACE_LEVEL
 
 from unit.test_util.mock_dns_object_creator import MockDnsObjectCreator
 from unit.test_util.valid_check_creator import ValidCheckCreator
@@ -94,6 +89,7 @@ class TestMpicDcvChecker:
             (DcvValidationMethod.ACME_HTTP_01, None),
             (DcvValidationMethod.ACME_DNS_01, None),
             (DcvValidationMethod.REVERSE_ADDRESS_LOOKUP, None),
+            (DcvValidationMethod.ACME_TLS_ALPN_01, None),
         ],
     )
     async def check_dcv__should_perform_appropriate_check_and_allow_issuance_given_target_record_found(
@@ -101,9 +97,11 @@ class TestMpicDcvChecker:
     ):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method, record_type)
         if dcv_method in (DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01):
-            self.mock_request_specific_http_response(dcv_request, mocker)
+            self._mock_request_specific_http_response(dcv_request, mocker)
+        elif dcv_method == DcvValidationMethod.ACME_TLS_ALPN_01:
+            self._mock_successful_tls_alpn_validation_entirely(dcv_request, mocker)
         else:
-            self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+            self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison
         assert dcv_response.check_passed is True
@@ -138,9 +136,9 @@ class TestMpicDcvChecker:
 
         # set up mocks prior which will return the original challenge value in the dcv_request
         if dcv_method in (DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01):
-            self.mock_request_specific_http_response(dcv_request, mocker)
+            self._mock_request_specific_http_response(dcv_request, mocker)
         else:
-            self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+            self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
 
         # set up the challenge value casing to be different from the original
         if dcv_method == DcvValidationMethod.ACME_HTTP_01:
@@ -172,7 +170,7 @@ class TestMpicDcvChecker:
         dns_response = MockDnsObjectCreator.create_dns_query_answer(
             dcv_request.domain_or_ip_target, "", record_type, mock_record_data_with_value, mocker
         )
-        self.patch_resolver_with_answer_or_exception(mocker, dns_response)
+        self._patch_resolver_with_answer_or_exception(mocker, dns_response)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison
         assert dcv_response.check_passed is False
@@ -194,7 +192,7 @@ class TestMpicDcvChecker:
         dns_response = MockDnsObjectCreator.create_dns_query_answer(
             dcv_request.domain_or_ip_target, "", record_type, mock_record_data_with_value, mocker
         )
-        self.patch_resolver_with_answer_or_exception(mocker, dns_response)
+        self._patch_resolver_with_answer_or_exception(mocker, dns_response)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         dcv_response.timestamp_ns = None  # ignore timestamp for comparison
         assert dcv_response.check_passed is True
@@ -211,11 +209,11 @@ class TestMpicDcvChecker:
         if dcv_method == DcvValidationMethod.WEBSITE_CHANGE:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
             dcv_request.domain_or_ip_target = encoded_domain  # do this first for mocking
-            self.mock_request_specific_http_response(dcv_request, mocker)
+            self._mock_request_specific_http_response(dcv_request, mocker)
         else:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
             dcv_request.domain_or_ip_target = encoded_domain  # do this first for mocking
-            self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+            self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
 
         dcv_request.domain_or_ip_target = domain  # set to original to see if the mock triggers as expected
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
@@ -235,16 +233,16 @@ class TestMpicDcvChecker:
         if dcv_method == DcvValidationMethod.WEBSITE_CHANGE:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.WEBSITE_CHANGE)
             if should_complete_check:
-                self.mock_request_specific_http_response(dcv_request, mocker)
+                self._mock_request_specific_http_response(dcv_request, mocker)
             else:
-                self.mock_error_http_response(mocker)
+                self._mock_error_http_response(mocker)
         else:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.ACME_DNS_01)
             if should_complete_check:
-                self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+                self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
             else:
                 timeout_error = dns.exception.Timeout()
-                self.patch_resolver_with_answer_or_exception(mocker, timeout_error)
+                self._patch_resolver_with_answer_or_exception(mocker, timeout_error)
 
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is should_complete_check
@@ -256,10 +254,10 @@ class TestMpicDcvChecker:
 
         if dcv_method == DcvValidationMethod.ACME_HTTP_01:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-            self.mock_request_specific_http_response(dcv_request, mocker)
+            self._mock_request_specific_http_response(dcv_request, mocker)
         else:
             dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-            self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+            self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
 
         await tracing_dcv_checker.check_dcv(dcv_request)
         log_contents = self.log_output.getvalue()
@@ -269,7 +267,7 @@ class TestMpicDcvChecker:
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.WEBSITE_CHANGE)
         dcv_request.trace_identifier = "test_trace_identifier"
 
-        self.mock_error_http_response(mocker)
+        self._mock_error_http_response(mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
         log_contents = self.log_output.getvalue()
@@ -278,14 +276,14 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_pass_given_token_file_found_with_expected_content(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is True
 
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_return_timestamp_and_response_url_and_status_code(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         match dcv_method:
             case DcvValidationMethod.WEBSITE_CHANGE:
@@ -301,16 +299,16 @@ class TestMpicDcvChecker:
 
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_not_pass_given_token_file_not_found(self, dcv_method, mocker):
-        fail_response = TestMpicDcvChecker.create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
-        self.mock_request_agnostic_http_response(fail_response, mocker)
+        fail_response = TestMpicDcvChecker._create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
+        self._mock_request_agnostic_http_response(fail_response, mocker)
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
 
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_return_error_details_given_token_file_not_found(self, dcv_method, mocker):
-        fail_response = TestMpicDcvChecker.create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
-        self.mock_request_agnostic_http_response(fail_response, mocker)
+        fail_response = TestMpicDcvChecker._create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
+        self._mock_request_agnostic_http_response(fail_response, mocker)
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
@@ -342,7 +340,7 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_not_pass_given_non_matching_response_content(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         if dcv_method == DcvValidationMethod.WEBSITE_CHANGE:
             dcv_request.dcv_check_parameters.challenge_value = "expecting-this-value-now-instead"
         else:
@@ -368,7 +366,7 @@ class TestMpicDcvChecker:
             case _:
                 dcv_request.dcv_check_parameters.token = "test-path"
                 url_scheme = "http"
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         expected_url = f"{url_scheme}://{dcv_request.domain_or_ip_target}/{expected_segment}/test-path"
         assert dcv_response.details.response_url == expected_url
@@ -384,9 +382,9 @@ class TestMpicDcvChecker:
             case _:
                 expected_challenge = dcv_request.dcv_check_parameters.key_authorization
 
-        history = self.create_http_redirect_history()
-        mock_response = TestMpicDcvChecker.create_mock_http_response(200, expected_challenge, {"history": history})
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        history = self._create_http_redirect_history()
+        mock_response = TestMpicDcvChecker._create_mock_http_response(200, expected_challenge, {"history": history})
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         redirects = dcv_response.details.response_history
         assert len(redirects) == 2
@@ -398,8 +396,8 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.WEBSITE_CHANGE, DcvValidationMethod.ACME_HTTP_01])
     async def http_based_dcv_checks__should_include_base64_encoded_response_page_in_details(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(b"aaa", "utf-8")
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(b"aaa", "utf-8")
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.details.response_page == base64.b64encode(b"aaa").decode()
 
@@ -408,8 +406,8 @@ class TestMpicDcvChecker:
         self, dcv_method, mocker
     ):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(b"a" * 1000, "utf-8")
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(b"a" * 1000, "utf-8")
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         hundred_a_chars_b64 = base64.b64encode(
             b"a" * 100
@@ -419,8 +417,8 @@ class TestMpicDcvChecker:
     async def http_based_dcv_checks__should_read_more_than_100_bytes_if_challenge_value_requires_it(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.WEBSITE_CHANGE)
         dcv_request.dcv_check_parameters.challenge_value = "".join(["a"] * 150)  # 150 'a' characters
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(b"a" * 1000, "utf-8")
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(b"a" * 1000, "utf-8")
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         hundred_fifty_a_chars_b64 = base64.b64encode(b"a" * 150).decode()  # store 150 chars in base64 encoded string
         assert len(dcv_response.details.response_page) == len(hundred_fifty_a_chars_b64)
@@ -434,8 +432,8 @@ class TestMpicDcvChecker:
         expected_challenge_value = "Café"
 
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(content, encoding)
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(content, encoding)
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         match dcv_method:
             case DcvValidationMethod.WEBSITE_CHANGE:
                 dcv_request.dcv_check_parameters.challenge_value = expected_challenge_value
@@ -452,7 +450,7 @@ class TestMpicDcvChecker:
             "User-Agent": "test-agent",
         }
         dcv_request.dcv_check_parameters.http_headers = headers
-        requests_get_mock = self.mock_request_specific_http_response(dcv_request, mocker)
+        requests_get_mock = self._mock_request_specific_http_response(dcv_request, mocker)
         await self.dcv_checker.check_dcv(dcv_request)
 
         assert requests_get_mock.call_args.kwargs["headers"] == headers
@@ -476,12 +474,12 @@ class TestMpicDcvChecker:
                 expected_challenge = dcv_request.dcv_check_parameters.key_authorization
 
         if code_or_port == "unacceptable_code":
-            history = self.create_http_redirect_history_with_disallowed_code()
+            history = self._create_http_redirect_history_with_disallowed_code()
         else:
-            history = self.create_http_redirect_history_with_disallowed_port()
+            history = self._create_http_redirect_history_with_disallowed_port()
 
-        mock_response = TestMpicDcvChecker.create_mock_http_response(200, expected_challenge, {"history": history})
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response(200, expected_challenge, {"history": history})
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
 
@@ -489,7 +487,7 @@ class TestMpicDcvChecker:
     async def website_change_validation__should_use_specified_url_scheme(self, url_scheme, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.url_scheme = url_scheme
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_http_based_validation(dcv_request)
         assert dcv_response.check_passed is True
         assert dcv_response.details.response_url.startswith(f"{url_scheme}://")
@@ -503,7 +501,7 @@ class TestMpicDcvChecker:
     ):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.challenge_value = challenge_value
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_request.dcv_check_parameters.challenge_value = "challenge-value"
         dcv_response = await self.dcv_checker.perform_http_based_validation(dcv_request)
         assert dcv_response.check_passed is check_passed
@@ -511,14 +509,14 @@ class TestMpicDcvChecker:
     async def website_change_validation__should_set_is_valid_true_with_regex_match(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.match_regex = "^challenge_[0-9]*$"
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_http_based_validation(dcv_request)
         assert dcv_response.check_passed is True
 
     async def website_change_validation__should_set_is_valid_false_with_regex_not_matching(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.match_regex = "^challenge_[2-9]*$"
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_http_based_validation(dcv_request)
         assert dcv_response.check_passed is False
 
@@ -528,8 +526,8 @@ class TestMpicDcvChecker:
             ""  # blank out challenge value to delegate all matching to regex
         )
         dcv_request.dcv_check_parameters.match_regex = "^" + "a" * 150 + "$"  # 150 'a' characters
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(b"a" * 150, "utf-8")
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(b"a" * 150, "utf-8")
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is True
         hundred_fifty_a_chars_b64 = base64.b64encode(b"a" * 150).decode()  # store 150 chars in base64 encoded string
@@ -539,10 +537,10 @@ class TestMpicDcvChecker:
         dcv_request = ValidCheckCreator.create_valid_http_check_request()
         dcv_request.dcv_check_parameters.challenge_value = ""
         dcv_request.dcv_check_parameters.match_regex = r"ABC123[\s]+(example.com|example.org|example.net)[\s]+XYZ789"
-        mock_response = TestMpicDcvChecker.create_mock_http_response_with_content_and_encoding(
+        mock_response = TestMpicDcvChecker._create_mock_http_response_with_content_and_encoding(
             b"ABC123\n\n\n\n\t example.com\n\n\n\t  XYZ789", "utf-8"
         )
-        self.mock_request_agnostic_http_response(mock_response, mocker)
+        self._mock_request_agnostic_http_response(mock_response, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is True
 
@@ -554,7 +552,7 @@ class TestMpicDcvChecker:
     ):
         dcv_request = ValidCheckCreator.create_valid_acme_http_01_check_request()
         dcv_request.dcv_check_parameters.key_authorization = key_authorization
-        self.mock_request_specific_http_response(dcv_request, mocker)
+        self._mock_request_specific_http_response(dcv_request, mocker)
         dcv_request.dcv_check_parameters.key_authorization = "challenge_111"
         dcv_response = await self.dcv_checker.perform_http_based_validation(dcv_request)
         assert dcv_response.check_passed is check_passed
@@ -562,7 +560,7 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize("record_type", [DnsRecordType.TXT, DnsRecordType.CNAME, DnsRecordType.CAA])
     async def dns_validation__should_pass_given_expected_dns_record_found(self, record_type, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
 
@@ -571,14 +569,14 @@ class TestMpicDcvChecker:
         dcv_request = ValidCheckCreator.create_valid_dns_check_request(record_type)
         # create string with null byte and utf-8 character
         dcv_request.dcv_check_parameters.challenge_value = "Mötley\0Crüe"
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
 
     async def dns_validation__should_allow_finding_expected_challenge_as_substring_by_default(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_CHANGE)
         dcv_request.dcv_check_parameters.challenge_value = "eXtRaStUfFchallenge-valueMoReStUfF"
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_request.dcv_check_parameters.challenge_value = "challenge-value"
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
@@ -586,7 +584,7 @@ class TestMpicDcvChecker:
     async def dns_validation__should_allow_finding_expected_challenge_exactly_if_specified(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_CHANGE)
         dcv_request.dcv_check_parameters.challenge_value = "challenge-value"
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_request.dcv_check_parameters.require_exact_match = True
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
@@ -595,7 +593,7 @@ class TestMpicDcvChecker:
     async def dns_validation__should_use_dns_name_prefix_if_provided(self, dns_name_prefix, mocker):
         dcv_request = ValidCheckCreator.create_valid_dns_check_request()
         dcv_request.dcv_check_parameters.dns_name_prefix = dns_name_prefix
-        mock_dns_resolver_resolve = self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
         if dns_name_prefix is not None and len(dns_name_prefix) > 0:
@@ -607,7 +605,7 @@ class TestMpicDcvChecker:
 
     async def acme_dns_validation__should_auto_insert_acme_challenge_prefix(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_acme_dns_01_check_request()
-        mock_dns_resolver_resolve = self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
         mock_dns_resolver_resolve.assert_called_once_with(
@@ -616,7 +614,7 @@ class TestMpicDcvChecker:
 
     async def contact_email_txt_lookup__should_auto_insert_validation_prefix(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_contact_check_request(DcvValidationMethod.CONTACT_EMAIL_TXT)
-        mock_dns_resolver_resolve = self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
         mock_dns_resolver_resolve.assert_called_once_with(
@@ -625,7 +623,7 @@ class TestMpicDcvChecker:
 
     async def contact_phone_txt_lookup__should_auto_insert_validation_prefix(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_contact_check_request(DcvValidationMethod.CONTACT_PHONE_TXT)
-        mock_dns_resolver_resolve = self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        mock_dns_resolver_resolve = self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is True
         mock_dns_resolver_resolve.assert_called_once_with(
@@ -650,7 +648,7 @@ class TestMpicDcvChecker:
         test_dns_query_answer = MockDnsObjectCreator.create_dns_query_answer(
             dcv_request.domain_or_ip_target, check_parameters.dns_name_prefix, DnsRecordType.CAA, record_data, mocker
         )
-        self.patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
+        self._patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is expected_result
 
@@ -661,7 +659,7 @@ class TestMpicDcvChecker:
         self, dcv_method, mocker
     ):
         dcv_request = ValidCheckCreator.create_valid_contact_check_request(dcv_method)
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         current_target = dcv_request.domain_or_ip_target
         dcv_request.domain_or_ip_target = f"sub2.sub1.{current_target}"
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
@@ -670,7 +668,7 @@ class TestMpicDcvChecker:
 
     async def contact_info_caa_lookup__should_not_pass_if_no_records_found_in_domain_tree(self, mocker):
         dcv_request = ValidCheckCreator.create_valid_contact_check_request(DcvValidationMethod.CONTACT_EMAIL_CAA)
-        self.mock_request_specific_dns_resolve_call(dcv_request, mocker)
+        self._mock_request_specific_dns_resolve_call(dcv_request, mocker)
         dcv_request.domain_or_ip_target = "sub2.sub1.sub0.nonexistent.com"
         dcv_response = await self.dcv_checker.perform_general_dns_validation(dcv_request)
         assert dcv_response.check_passed is False
@@ -678,19 +676,19 @@ class TestMpicDcvChecker:
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.ACME_DNS_01])
     async def dns_based_dcv_checks__should_not_pass_given_non_matching_dns_record(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
+        test_dns_query_answer = self._create_basic_dns_response_for_mock(dcv_request, mocker)
         test_dns_query_answer.response.answer[0].items.clear()
         test_dns_query_answer.response.answer[0].add(
             MockDnsObjectCreator.create_record_by_type(DnsRecordType.TXT, {"value": "not-the-expected-value"})
         )
-        self.patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
+        self._patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.check_passed is False
 
     @pytest.mark.parametrize("dcv_method", [DcvValidationMethod.DNS_CHANGE, DcvValidationMethod.ACME_DNS_01])
     async def dns_based_dcv_checks__should_return_timestamp_and_list_of_records_seen(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_dns_resolve_call_getting_multiple_txt_records(dcv_request, mocker)
+        self._mock_dns_resolve_call_getting_multiple_txt_records(dcv_request, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         if dcv_method == DcvValidationMethod.DNS_CHANGE:
             expected_value_1 = dcv_request.dcv_check_parameters.challenge_value
@@ -710,7 +708,7 @@ class TestMpicDcvChecker:
     )
     async def dns_based_dcv_checks__should_return_response_code(self, dcv_method, response_code, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_dns_resolve_call_with_specific_response_code(dcv_request, response_code, mocker)
+        self._mock_dns_resolve_call_with_specific_response_code(dcv_request, response_code, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.details.response_code == response_code
 
@@ -727,7 +725,7 @@ class TestMpicDcvChecker:
         self, dcv_method, flag, flag_set, mocker
     ):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
-        self.mock_dns_resolve_call_with_specific_flag(dcv_request, flag, mocker)
+        self._mock_dns_resolve_call_with_specific_flag(dcv_request, flag, mocker)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         assert dcv_response.details.ad_flag is flag_set
 
@@ -735,7 +733,7 @@ class TestMpicDcvChecker:
     async def dns_based_dcv_checks__should_not_pass_with_errors_given_exception_raised(self, dcv_method, mocker):
         dcv_request = ValidCheckCreator.create_valid_dcv_check_request(dcv_method)
         no_answer_error = dns.resolver.NoAnswer()
-        self.patch_resolver_with_answer_or_exception(mocker, no_answer_error)
+        self._patch_resolver_with_answer_or_exception(mocker, no_answer_error)
         dcv_response = await self.dcv_checker.check_dcv(dcv_request)
         errors = [
             MpicValidationError.create(
@@ -766,7 +764,7 @@ class TestMpicDcvChecker:
         return _raise()
 
     @staticmethod
-    def create_base_client_response_for_mock(event_loop):
+    def _create_base_client_response_for_mock(event_loop):
         return ClientResponse(
             method="GET",
             url=URL("http://example.com"),
@@ -780,9 +778,9 @@ class TestMpicDcvChecker:
         )
 
     @staticmethod
-    def create_mock_http_response(status_code: int, content: str, kwargs: dict = None):
+    def _create_mock_http_response(status_code: int, content: str, kwargs: dict = None):
         event_loop = asyncio.get_event_loop()
-        response = TestMpicDcvChecker.create_base_client_response_for_mock(event_loop)
+        response = TestMpicDcvChecker._create_base_client_response_for_mock(event_loop)
         response.status = status_code
 
         default_headers = {"Content-Type": "text/plain; charset=utf-8", "Content-Length": str(len(content))}
@@ -804,9 +802,9 @@ class TestMpicDcvChecker:
         return response
 
     @staticmethod
-    def create_mock_http_redirect_response(status_code: int, redirect_url: str):
+    def _create_mock_http_redirect_response(status_code: int, redirect_url: str):
         event_loop = asyncio.get_event_loop()
-        response = TestMpicDcvChecker.create_base_client_response_for_mock(event_loop)
+        response = TestMpicDcvChecker._create_base_client_response_for_mock(event_loop)
         response.status = status_code
         # Set both the Location header and the URL property
         redirect_url = URL(redirect_url)
@@ -814,9 +812,9 @@ class TestMpicDcvChecker:
         return response
 
     @staticmethod
-    def create_mock_http_response_with_content_and_encoding(content: bytes, encoding: str):
+    def _create_mock_http_response_with_content_and_encoding(content: bytes, encoding: str):
         event_loop = asyncio.get_event_loop()
-        response = TestMpicDcvChecker.create_base_client_response_for_mock(event_loop)
+        response = TestMpicDcvChecker._create_base_client_response_for_mock(event_loop)
         response.status = 200
         response._headers = CIMultiDictProxy(CIMultiDict({"Content-Type": f"text/plain; charset={encoding}"}))
         response.content = StreamReader(loop=event_loop)
@@ -824,7 +822,7 @@ class TestMpicDcvChecker:
         response.content.feed_eof()
         return response
 
-    def mock_request_specific_http_response(self, dcv_request: DcvCheckRequest, mocker):
+    def _mock_request_specific_http_response(self, dcv_request: DcvCheckRequest, mocker):
         match dcv_request.dcv_check_parameters.validation_method:
             case DcvValidationMethod.WEBSITE_CHANGE:
                 url_scheme = dcv_request.dcv_check_parameters.url_scheme
@@ -836,8 +834,8 @@ class TestMpicDcvChecker:
                 expected_url = f"http://{dcv_request.domain_or_ip_target}/{MpicDcvChecker.WELL_KNOWN_ACME_PATH}/{token}"  # noqa E501 (http)
                 expected_challenge = dcv_request.dcv_check_parameters.key_authorization
 
-        success_response = TestMpicDcvChecker.create_mock_http_response(200, expected_challenge)
-        not_found_response = TestMpicDcvChecker.create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
+        success_response = TestMpicDcvChecker._create_mock_http_response(200, expected_challenge)
+        not_found_response = TestMpicDcvChecker._create_mock_http_response(404, "Not Found", {"reason": "Not Found"})
 
         # noinspection PyProtectedMember
         return mocker.patch(
@@ -849,7 +847,7 @@ class TestMpicDcvChecker:
             ),
         )
 
-    def mock_series_of_http_responses(self, responses: List[ClientResponse], mocker):
+    def _mock_series_of_http_responses(self, responses: List[ClientResponse], mocker):
         responses_iter = iter(responses)
 
         return mocker.patch(
@@ -859,13 +857,13 @@ class TestMpicDcvChecker:
             ),
         )
 
-    def mock_request_agnostic_http_response(self, mock_response: ClientResponse, mocker):
+    def _mock_request_agnostic_http_response(self, mock_response: ClientResponse, mocker):
         return mocker.patch(
             "aiohttp.ClientSession.get",
             side_effect=lambda *args, **kwargs: AsyncMock(__aenter__=AsyncMock(return_value=mock_response)),
         )
 
-    def mock_error_http_response(self, mocker):
+    def _mock_error_http_response(self, mocker):
         # noinspection PyUnusedLocal
         async def side_effect(url, headers):
             raise ClientConnectionError()
@@ -876,19 +874,19 @@ class TestMpicDcvChecker:
             side_effect=lambda *args, **kwargs: AsyncMock(__aenter__=AsyncMock(side_effect=ClientConnectionError())),
         )
 
-    def patch_resolver_resolve_with_side_effect(self, mocker, side_effect):
+    def _patch_resolver_resolve_with_side_effect(self, mocker, side_effect):
         return mocker.patch("dns.asyncresolver.resolve", new_callable=AsyncMock, side_effect=side_effect)
 
-    def patch_resolver_with_answer_or_exception(self, mocker, mocked_response_or_exception):
+    def _patch_resolver_with_answer_or_exception(self, mocker, mocked_response_or_exception):
         # noinspection PyUnusedLocal
         async def side_effect(domain_name, rdtype):
             if isinstance(mocked_response_or_exception, Exception):
                 raise mocked_response_or_exception
             return mocked_response_or_exception
 
-        return self.patch_resolver_resolve_with_side_effect(mocker, side_effect)
+        return self._patch_resolver_resolve_with_side_effect(mocker, side_effect)
 
-    def mock_request_specific_dns_resolve_call(self, dcv_request: DcvCheckRequest, mocker) -> MagicMock:
+    def _mock_request_specific_dns_resolve_call(self, dcv_request: DcvCheckRequest, mocker) -> MagicMock:
         dns_name_prefix = dcv_request.dcv_check_parameters.dns_name_prefix
         if dns_name_prefix is not None and len(dns_name_prefix) > 0:
             expected_domain = f"{dns_name_prefix}.{dcv_request.domain_or_ip_target}"
@@ -902,7 +900,7 @@ class TestMpicDcvChecker:
                 expected_domain = f"_validation-contactemail.{dcv_request.domain_or_ip_target}"
             case DcvValidationMethod.CONTACT_PHONE_CAA | DcvValidationMethod.CONTACT_EMAIL_CAA:
                 expected_domain = dns.name.from_text(expected_domain)  # CAA -- using dns names instead of strings
-        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
+        test_dns_query_answer = self._create_basic_dns_response_for_mock(dcv_request, mocker)
 
         # noinspection PyUnusedLocal
         async def side_effect(domain_name, rdtype):
@@ -910,19 +908,19 @@ class TestMpicDcvChecker:
                 return test_dns_query_answer
             raise self.raise_(dns.resolver.NoAnswer)
 
-        return self.patch_resolver_resolve_with_side_effect(mocker, side_effect)
+        return self._patch_resolver_resolve_with_side_effect(mocker, side_effect)
 
-    def mock_dns_resolve_call_with_specific_response_code(self, dcv_request: DcvCheckRequest, response_code, mocker):
-        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
+    def _mock_dns_resolve_call_with_specific_response_code(self, dcv_request: DcvCheckRequest, response_code, mocker):
+        test_dns_query_answer = self._create_basic_dns_response_for_mock(dcv_request, mocker)
         test_dns_query_answer.response.rcode = lambda: response_code
-        self.patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
+        self._patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
 
-    def mock_dns_resolve_call_with_specific_flag(self, dcv_request: DcvCheckRequest, flag, mocker):
-        test_dns_query_answer = self.create_basic_dns_response_for_mock(dcv_request, mocker)
+    def _mock_dns_resolve_call_with_specific_flag(self, dcv_request: DcvCheckRequest, flag, mocker):
+        test_dns_query_answer = self._create_basic_dns_response_for_mock(dcv_request, mocker)
         test_dns_query_answer.response.flags |= flag
-        self.patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
+        self._patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
 
-    def mock_dns_resolve_call_getting_multiple_txt_records(self, dcv_request: DcvCheckRequest, mocker):
+    def _mock_dns_resolve_call_getting_multiple_txt_records(self, dcv_request: DcvCheckRequest, mocker):
         check_parameters = dcv_request.dcv_check_parameters
         match check_parameters.validation_method:
             case DcvValidationMethod.DNS_CHANGE:
@@ -941,9 +939,9 @@ class TestMpicDcvChecker:
             *[txt_record_1, txt_record_2, txt_record_3],
             mocker=mocker,
         )
-        self.patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
+        self._patch_resolver_with_answer_or_exception(mocker, test_dns_query_answer)
 
-    def create_basic_dns_response_for_mock(self, dcv_request: DcvCheckRequest, mocker) -> dns.resolver.Answer:
+    def _create_basic_dns_response_for_mock(self, dcv_request: DcvCheckRequest, mocker) -> dns.resolver.Answer:
         check_parameters = dcv_request.dcv_check_parameters
         match check_parameters.validation_method:
             case (
@@ -970,22 +968,33 @@ class TestMpicDcvChecker:
         )
         return test_dns_query_answer
 
-    def create_http_redirect_history(self):
+    def _create_http_redirect_history(self):
         redirect_url_1 = f"https://example.com/redirected-1"
-        redirect_response_1 = TestMpicDcvChecker.create_mock_http_redirect_response(301, redirect_url_1)
+        redirect_response_1 = TestMpicDcvChecker._create_mock_http_redirect_response(301, redirect_url_1)
         redirect_url_2 = f"https://example.com/redirected-2"
-        redirect_response_2 = TestMpicDcvChecker.create_mock_http_redirect_response(302, redirect_url_2)
+        redirect_response_2 = TestMpicDcvChecker._create_mock_http_redirect_response(302, redirect_url_2)
         return [redirect_response_1, redirect_response_2]
 
-    def create_http_redirect_history_with_disallowed_code(self):
+    def _create_http_redirect_history_with_disallowed_code(self):
         redirect_url = f"https://example.com/redirected-1"
-        redirect_response = TestMpicDcvChecker.create_mock_http_redirect_response(303, redirect_url)
+        redirect_response = TestMpicDcvChecker._create_mock_http_redirect_response(303, redirect_url)
         return [redirect_response]
 
-    def create_http_redirect_history_with_disallowed_port(self):
+    def _create_http_redirect_history_with_disallowed_port(self):
         redirect_url = f"https://example.com:8080/redirected-1"
-        redirect_response = TestMpicDcvChecker.create_mock_http_redirect_response(301, redirect_url)
+        redirect_response = TestMpicDcvChecker._create_mock_http_redirect_response(301, redirect_url)
         return [redirect_response]
+
+    def _mock_successful_tls_alpn_validation_entirely(self, dcv_request, mocker):
+        response = DcvCheckResponse(
+            check_passed=True,
+            check_completed=True,
+            details=DcvCheckResponseDetailsBuilder.build_response_details(DcvValidationMethod.ACME_TLS_ALPN_01),
+        )
+        response.details.common_name = dcv_request.domain_or_ip_target
+        mocker.patch.object(
+            DcvTlsAlpnValidator, "perform_tls_alpn_validation", return_value=response
+        )
 
     @staticmethod
     def shuffle_case(string_to_shuffle: str) -> str:

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -4,6 +4,7 @@ from open_mpic_core import (
     CaaCheckParameters,
     DcvAcmeHttp01ValidationParameters,
     DcvAcmeDns01ValidationParameters,
+    DcvAcmeTlsAlpn01ValidationParameters,
     DcvIpAddressValidationParameters,
     DcvContactEmailCaaValidationParameters,
     DcvContactEmailTxtValidationParameters,
@@ -92,9 +93,18 @@ class ValidCheckCreator:
 
     @staticmethod
     def create_valid_acme_dns_01_check_request():
+        challenge = "challenge_111".encode().hex()
         return DcvCheckRequest(
             domain_or_ip_target="example.com",
-            dcv_check_parameters=DcvAcmeDns01ValidationParameters(key_authorization_hash="challenge_111"),
+            dcv_check_parameters=DcvAcmeDns01ValidationParameters(key_authorization_hash=challenge),
+        )
+
+    @staticmethod
+    def create_valid_acme_tls_alpn_01_check_request():
+        challenge = "challenge_111".encode().hex()
+        return DcvCheckRequest(
+            domain_or_ip_target="example.com",
+            dcv_check_parameters=DcvAcmeTlsAlpn01ValidationParameters(key_authorization_hash=challenge),
         )
 
     @staticmethod
@@ -106,16 +116,20 @@ class ValidCheckCreator:
         )
 
     @staticmethod
-    def create_valid_dcv_check_request(validation_method: DcvValidationMethod, record_type=DnsRecordType.TXT):
+    def create_valid_dcv_check_request(validation_method: DcvValidationMethod, record_type=None):
         match validation_method:
             case DcvValidationMethod.WEBSITE_CHANGE:
                 return ValidCheckCreator.create_valid_http_check_request()
             case DcvValidationMethod.DNS_CHANGE:
+                if record_type is None:
+                    record_type = DnsRecordType.TXT
                 return ValidCheckCreator.create_valid_dns_check_request(record_type)
             case DcvValidationMethod.ACME_HTTP_01:
                 return ValidCheckCreator.create_valid_acme_http_01_check_request()
             case DcvValidationMethod.ACME_DNS_01:
                 return ValidCheckCreator.create_valid_acme_dns_01_check_request()
+            case DcvValidationMethod.ACME_TLS_ALPN_01:
+                return ValidCheckCreator.create_valid_acme_tls_alpn_01_check_request()
             case DcvValidationMethod.IP_ADDRESS:
                 return ValidCheckCreator.create_valid_ip_lookup_check_request(record_type)
             case DcvValidationMethod.REVERSE_ADDRESS_LOOKUP:
@@ -127,3 +141,5 @@ class ValidCheckCreator:
                 | DcvValidationMethod.CONTACT_PHONE_TXT
             ):
                 return ValidCheckCreator.create_valid_contact_check_request(validation_method)
+            case _:
+                return None

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -142,4 +142,4 @@ class ValidCheckCreator:
             ):
                 return ValidCheckCreator.create_valid_contact_check_request(validation_method)
             case _:
-                return None
+                raise ValueError(f"Unsupported validation method: {validation_method}")

--- a/tests/unit/test_util/valid_check_creator.py
+++ b/tests/unit/test_util/valid_check_creator.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from open_mpic_core import (
     DcvWebsiteChangeValidationParameters,
     DcvDnsChangeValidationParameters,
@@ -101,10 +103,11 @@ class ValidCheckCreator:
 
     @staticmethod
     def create_valid_acme_tls_alpn_01_check_request():
-        challenge = "challenge_111".encode().hex()
+        challenge = "example-token.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI"
+        hash_bytes_hex = hashlib.sha256(challenge.encode("utf-8")).digest().hex()
         return DcvCheckRequest(
             domain_or_ip_target="example.com",
-            dcv_check_parameters=DcvAcmeTlsAlpn01ValidationParameters(key_authorization_hash=challenge),
+            dcv_check_parameters=DcvAcmeTlsAlpn01ValidationParameters(key_authorization_hash=hash_bytes_hex),
         )
 
     @staticmethod


### PR DESCRIPTION
Adding rudimentary unit testing to ensure coverage at least in terms of business logic. Getting us back to 99%. Tweaked logic a tad but kept it mostly intact. Added setting of `common_name` as per spec.