### PR TITLE
check criticalness of id-pe-acmeIdentifier 

### DIFF
--- a/src/open_mpic_core/common_domain/messages/ErrorMessages.py
+++ b/src/open_mpic_core/common_domain/messages/ErrorMessages.py
@@ -13,6 +13,7 @@ class ErrorMessages(Enum):
     COHORT_CREATION_ERROR = ('mpic_error:coordinator:cohort', 'The coordinator could not construct a cohort of size {0}')
 
     TLS_ALPN_ERROR_CERTIFICATE_EXTENSION_MISSING = ('mpic_error:dcv_checker:tls_alpn:certificate:extension_missing', 'The TLS ALPN certificate was missing an extension.')
+    TLS_ALPN_ERROR_CERTIFICATE_ALPN_EXTENSION_NONCRITICAL = ('mpic_error:dcv_checker:tls_alpn:certificate:noncritical_alpn_extension', 'The TLS ALPN certificate has non-critical id-pe-acmeIdentifier extension')
     TLS_ALPN_ERROR_CERTIFICATE_NO_SINGLE_SAN = ('mpic_error:dcv_checker:tls_alpn:certificate:no_single_san', 'The TLS ALPN certificate must have a single SAN entry.')
     TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_DNSNAME = ('mpic_error:dcv_checker:tls_alpn:certificate:san_not_dnsname', 'The TLS ALPN certificate SAN was not a DNSName.')
     TLS_ALPN_ERROR_CERTIFICATE_SAN_NOT_HOSTNAME = ('mpic_error:dcv_checker:tls_alpn:certificate:san_not_hostname', 'The TLS ALPN certificate SAN was not equal to the hostname being validated.')

--- a/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
+++ b/src/open_mpic_core/mpic_dcv_checker/dcv_tls_alpn_validator.py
@@ -64,8 +64,13 @@ class DcvTlsAlpnValidator:
                     else:
                         # We now know we have both extensions present. Begin checking each one.
                         dcv_check_response.errors = self._validate_san_entry(subject_alt_name_extension, hostname)
+                        if acme_tls_alpn_extension.critical != True:
+                            # id-pe-acmeIdentifier extension needs to be critical
+                                dcv_check_response.errors.append(
+                                    MpicValidationError.create(ErrorMessages.TLS_ALPN_ERROR_CERTIFICATE_ALPN_EXTENSION_NONCRITICAL)
+                                    )
                         if len(dcv_check_response.errors) == 0:
-                            # Check the id-pe-acmeIdentifier extension.
+                            # Check the id-pe-acmeIdentifier extension's value.
                             binary_challenge_seen = acme_tls_alpn_extension.value.value
                             key_authorization_hash_binary = None
                             try:

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -31,9 +31,7 @@ class MpicDcvChecker:
     WELL_KNOWN_ACME_PATH = ".well-known/acme-challenge"
     CONTACT_EMAIL_TAG = "contactemail"
     CONTACT_PHONE_TAG = "contactphone"
-
-    ACME_TLS_ALPN_OID_DOTTED_STRING = "1.3.6.1.5.5.7.1.31" # See id-pe-acmeIdentifier in https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml
-    SUBJECT_ALT_NAME_OID_DOTTED_STRING = "2.5.29.17"
+# acme_tls_alpn related constants are in ./dcv_tls_alpn_validator.py
 
     def __init__(
         self,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8737#section-3-4 says 
>>for the challenge. The acmeIdentifier extension MUST be critical so that the certificate isn't inadvertently used by non-ACME software

this PR impliments this check:

P.S after this we need to block of ip identifier for tls-alpn or actually handle ip address in request: currently this will check as if it was DNS name, and it need quite a lot of special handling to do it properly