### PR TITLE
block not suitable methods from wildcard domain validation

### DIFF
--- a/src/open_mpic_core/common_domain/messages/ErrorMessages.py
+++ b/src/open_mpic_core/common_domain/messages/ErrorMessages.py
@@ -4,6 +4,7 @@ from enum import Enum
 class ErrorMessages(Enum):
     CAA_LOOKUP_ERROR = ('mpic_error:caa_checker:lookup', 'There was an error looking up the CAA record: {0}')
     DCV_LOOKUP_ERROR = ('mpic_error:dcv_checker:lookup', 'There was an error looking up the DCV record. Error type: {0}, Error message: {1}')
+    DCV_UNSUITABLE_TYPE_ERROR = ('mpic_error:dcv_checker:malformed', '{0} is not allowed to use for validate {1}.')
     COORDINATOR_COMMUNICATION_ERROR = ('mpic_error:coordinator:communication', 'Communication with the remote perspective failed.')
     COORDINATOR_REMOTE_CHECK_ERROR = ('mpic_error:coordinator:remote_check', 'The remote check failed to complete: {0}')
     TOO_MANY_FAILED_PERSPECTIVES_ERROR = ('mpic_error:coordinator:too_many_failed_perspectives', 'Too many perspectives failed to complete the check.')

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -32,6 +32,13 @@ class MpicDcvChecker:
     CONTACT_EMAIL_TAG = "contactemail"
     CONTACT_PHONE_TAG = "contactphone"
 
+    UNSUITABLE_FOR_WILDCARD = [
+        DcvValidationMethod.WEBSITE_CHANGE,
+        DcvValidationMethod.ACME_HTTP_01,
+        DcvValidationMethod.IP_ADDRESS,
+        DcvValidationMethod.ACME_TLS_ALPN_01
+    ]
+
     def __init__(
         self,
         http_client_timeout: float = 30,
@@ -99,6 +106,15 @@ class MpicDcvChecker:
         # noinspection PyUnresolvedReferences
         self.logger.trace(f"Checking DCV for {dcv_request.domain_or_ip_target} with method {validation_method}.")
 
+        # some validation methods are banned from using for wildcard validation
+        if dcv_request.domain_or_ip_target.startswith("*."):
+            if validation_method in [
+                DcvValidationMethod.IP_ADDRESS,
+                DcvValidationMethod.WEBSITE_CHANGE,
+                DcvValidationMethod.ACME_HTTP_01,
+                DcvValidationMethod.ACME_TLS_ALPN_01
+            ]:
+                raise ValueError(f'{validation_method} cannot be used for validating wildcard domain name')
         # encode domain if needed
         dcv_request.domain_or_ip_target = DomainEncoder.prepare_target_for_lookup(dcv_request.domain_or_ip_target)
 

--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -114,7 +114,12 @@ class MpicDcvChecker:
                 DcvValidationMethod.ACME_HTTP_01,
                 DcvValidationMethod.ACME_TLS_ALPN_01
             ]:
-                raise ValueError(f'{validation_method} cannot be used for validating wildcard domain name')
+               result = MpicDcvChecker.create_empty_check_response(validation_method)
+               result.timestamp_ns = time.time_ns()
+               result.errors = [
+                MpicValidationError.create(ErrorMessages.DCV_UNSUITABLE_TYPE_ERROR, validation_method, 'wildcard domain')
+            ]
+               return result
         # encode domain if needed
         dcv_request.domain_or_ip_target = DomainEncoder.prepare_target_for_lookup(dcv_request.domain_or_ip_target)
 


### PR DESCRIPTION
CA/B BR forbids some method from using for wildcard domain, at the end of each validation method's description as note.
 for example at the end of 3.2.2.4.8 IP Address validation method:

Note: Once the FQDN has been validated using this method, the CA MUST NOT issue Certificates
for other FQDNs that end with all the labels of the validated FQDN unless the CA performs separate
validations for each of those other FQDNs using authorized methods. This method is NOT suitable
for validating Wildcard Domain Names.