### PR TITLE
Add dummy cookie jar to HTTP client sessions

### DIFF
--- a/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/open_mpic_core/mpic_dcv_checker/mpic_dcv_checker.py
@@ -78,15 +78,21 @@ class MpicDcvChecker:
                     await self._async_http_client.close()
 
                 connector = aiohttp.TCPConnector(ssl=self.verify_ssl, limit=0)  # no limit on simultaneous connections
+                dummy_cookie_jar = aiohttp.DummyCookieJar()  # disable cookie processing
                 self._async_http_client = aiohttp.ClientSession(
-                    connector=connector, timeout=aiohttp.ClientTimeout(total=self._http_client_timeout)
+                    connector=connector,
+                    timeout=aiohttp.ClientTimeout(total=self._http_client_timeout),
+                    cookie_jar=dummy_cookie_jar,
                 )
                 self._http_client_loop = current_loop
             yield self._async_http_client
         else:  # implementations such as AWS Lambda will need a new client for each invocation
             connector = aiohttp.TCPConnector(ssl=self.verify_ssl, limit=0)
+            dummy_cookie_jar = aiohttp.DummyCookieJar()  # disable cookie processing
             client = aiohttp.ClientSession(
-                connector=connector, timeout=aiohttp.ClientTimeout(total=self._http_client_timeout)
+                connector=connector,
+                timeout=aiohttp.ClientTimeout(total=self._http_client_timeout),
+                cookie_jar=dummy_cookie_jar,
             )
             try:
                 yield client


### PR DESCRIPTION
Introduce a dummy cookie jar to disable cookie processing in HTTP client sessions, enhancing control over HTTP requests.